### PR TITLE
Allow popstate event to propagate

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -50,7 +50,7 @@ jobs:
           draft: true
           files: |
             dist/PdNaja.esm.js
-            dist/PdNaja.ems.js.map
+            dist/PdNaja.esm.js.map
 
   publish:
     name: Publish

--- a/README.md
+++ b/README.md
@@ -21,13 +21,13 @@ naja.registerExtension(new ExtensionName())
 ```typescript
 import { controlManager } from '@peckadesign/pd-naja'
 import SomeControl from '@/js/Controls/SomeControl' // `SomeControl` must implement `Control` interface
-import SomeAnotherControl from '@/js/Controls/SomeControl'
+import SomeAnotherControl from '@/js/Controls/SomeAnotherControl'
 
 // This control is only initialized on page load
 controlManager.addControlOnLoad(SomeControl)
 
 // This control will also get initialized after Naja requests
-controlManager.addControlOnLive(SomeControl)
+controlManager.addControlOnLive(SomeAnotherControl)
 
 ```
 

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
 	"version": "1.0.1",
 	"private": false,
 	"description": "Utilities and extensions created for use with Naja library.",
+	"main": "dist/PdNaja.esm.js",
 	"module": "dist/PdNaja.esm.js",
 	"types": "dist/index.esm.d.ts",
 	"repository": {


### PR DESCRIPTION
When non-modal state has been retrieved, `event.stopImmediatePropagation()` has been called. That caused non related popstate handlers from other extension or third party scripts not be run. This call was originally added to prevent extra request when closing the modal opened with snippet cache off. It is now handled with different approach - when closing the modal, we set a flag `shouldPreventSnippetFetch` and based on this flag, we call `event.preventDefault()` inside `FetchEvent` handler.

Also when snippet cache was off, the `modalOpener` and `modalOptions` were not properly set in options (should be retrieved from `state`), which might have caused errors. Now those properties are also set when they should be.

BREAKING CHANGE: `AjaxModal` interface changed, `show` method argument `opener` is always of type `Element`. `pdModal` inside history state is only present when modal is opened (should be used internally only anyway).