### PR TITLE
feature: `Control` provides optional method `detroy`

### DIFF
--- a/src/utils/Control.ts
+++ b/src/utils/Control.ts
@@ -13,6 +13,10 @@
 // 3. In case of `addControlOnLive` used, the `initialize` method is also called for each success ajax request. The
 //    `context` argument is equal to modified nette snippet.
 //
+// There is also optional method `destroy`. This method is called for each snippet before its content is being replaced.
+// It is only called on snippets where operation is equal to naja.snippetHandler.
 export default interface Control {
 	initialize(context: Element | Document): void
+
+	destroy?(context: Element): void
 }


### PR DESCRIPTION
`Control`s might have an optional method `destroy`. If this method is present, it is called before snippet's content is being replaced, allowing to destroy any previously initialized JS. This method is only called on snippets, where content is being replaced; when `append` or `prepend` operation is used, method is not called as in that case, previously initialized JS content remains intact in those snippets.