### PR TITLE
chore: publish to private registry as well

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -52,8 +52,8 @@ jobs:
             dist/PdNaja.esm.js
             dist/PdNaja.esm.js.map
 
-  publish:
-    name: Publish
+  publishPublic:
+    name: Publish (public)
     runs-on: ubuntu-latest
     needs: [build]
     steps:
@@ -76,3 +76,28 @@ jobs:
         run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
+
+  publishPrivate:
+    name: Publish (private)
+    runs-on: ubuntu-latest
+    needs: [build]
+    steps:
+      - name: Checkout 🛎
+        uses: actions/checkout@v3
+
+      - name: Download artifacts 🧩
+        uses: actions/download-artifact@v3
+        with:
+          name: dist-files
+          path: dist/
+
+      - name: Setup Node 📦
+        uses: actions/setup-node@v3
+        with:
+          node-version: lts/*
+          registry-url: 'https://npm.pkg.github.com'
+
+      - name: Publish release 🕊️
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Package is published also into private github registry.

Successful publication can be seen in action run https://github.com/peckadesign/pd-naja/actions/runs/6170991653/job/16748372166?pr=5, now the trigger is reverted back to tag release.