### PR TITLE
feature: new extensions added

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,10 @@ This package provides easy ways to add JS components reactive to Naja ajax event
 
 2. The instantiated class is then added to ControlManager either by `addControlOnLoad` or `addControlOnLive`. This ensures, that on `DOMContentLoaded` the `initialize` function of class is called. This method should implement initialization of the control dependent on fully loaded DOM. The `context` argument is equal to `document` in this call.
 
-3. In case of `addControlOnLive` used, the `initialize` method is also called for each success ajax request. The `context` argument is equal to modified nette snippet.
+3. In the case of using `addControlOnLive`, two methods are called after each successful Ajax request:
+   1. **Optional:** Just before the snippet update, the optional `destroy` method is called. It will only be called if the [snippet update operation](https://naja.js.org/#/snippets?id=snippet-update-operation) is `replace`.
+
+   2. The `initialize` method is called for each snippet. It is called immediately after the snippet has been updated. The `context` argument is equal to the modified nette snippet.
 
 
 ## Extensions
@@ -70,6 +73,25 @@ naja.registerExtension(
 | `dispatchLoad?: (options: any, event: SuccessEvent \| PopStateEvent) => void`                                                                 | If you provide this method, extension will call it whenever the content is changed (loaded).                                                                                                                                                                                                                                                           |
 | `getOptions(opener: Element): any`                                                                                                            | If you need to change some modal settings based on opener element, you can do that in this function. Return value of this function is stored in `localStorage` (or wherever is Naja configured to store states) and also in `HistoryState`. Bear in mind that this introduces some limitations of what can be returned (e.g. no `Element` is allowed). | 
 | `setOptions(options: any): void`                                                                                                              | Counterpart of `getOptions` method, you can use this method to restore modal settings based on `options`.                                                                                                                                                                                                                                              |
+
+### `AjaxModalPreventRedrawExtension`
+Occasionally we may have an ajax request invoked inside the modal window, but this request is not related to the modal window itself. However, because it is invoked from within the modal window, the HTTP header `Pd-Modal-Opened` is set. If enabled, this extension adds another header to the request, namely `Pd-Modal-Prevent-Redraw`. The extension can be enabled by adding the `data-naja-modal-prevent-redraw` data attribute to the interacted element, or by adding `pdModalPreventRedraw` to options.
+
+
+### `AjaxOnceExtension`
+This extension allows you to specify for a given element that the request will only be made on the first interaction. For example, for collapsible boxes, it is possible to make the request only once, when they are expanded for the first time. It is enabled by setting `data-naja-once` on the interacted element and allows the same element to control the collapsible box and make a request at the same time, without creating multiple unnecessary requests.
+
+### `ConfirmExtension`
+Simple extension that uses `window.confirm` before making the request, allowing the user to prevent the request from being made. It is enabled by setting the data attribute `data-confirm`. The value of the attribute is used as a parameter for the `window.confirm` call.
+
+### `FollowUpRequestExtension`
+This extension allows you to chain multiple requests. This is useful, for example, within modals, where after redrawing the modal, you may need to redraw the page below it as well. This page may be from a different presenter, so you need to redraw with a different request. When used, this extension checks for the presence of `followUpUrl` in the payload. This is the URL to which the follow up request will be made.
+
+### `ForceRedirectExtension`
+This extension allows you to force redirect the page to a specific URL. When imported, it checks for the presence of `forceRedirect` in the payload and then redirects to it. 
+
+### `ForceReplaceExtension`
+If you are using content prepending or appending on snippets, you may need to force replace their content when certain elements have been interacted with. For example, if you have an infinite pager with new items appended, you may need to clear the snippet when some sort of filtering request has been made. This extension changes the snippet operation to `replace` when enabled by using the `data-naja-snippet-force-replace attribute` on the interacted element. See [Snippet update operation](https://naja.js.org/#/snippets?id=snippet-update-operation) in the Naja docs for more information about update operations.
 
 ### `SpinnerExtension`
 

--- a/src/extensions/AjaxModalPreventRedrawExtension.ts
+++ b/src/extensions/AjaxModalPreventRedrawExtension.ts
@@ -1,0 +1,31 @@
+import { BeforeEvent, Extension, Naja } from 'naja/dist/Naja'
+import { InteractionEvent } from 'naja/dist/core/UIHandler'
+
+declare module 'naja/dist/Naja' {
+	interface Options {
+		pdModalPreventRedraw?: boolean
+	}
+}
+
+export class AjaxModalPreventRedrawExtension implements Extension {
+	public initialize(naja: Naja): void {
+		naja.uiHandler.addEventListener('interaction', this.handleInteraction.bind(this))
+		naja.addEventListener('before', this.handleBefore.bind(this))
+	}
+
+	private handleInteraction(event: InteractionEvent): void {
+		const { element, options } = event.detail
+
+		if (element.hasAttribute('data-naja-modal-prevent-redraw')) {
+			options.pdModalPreventRedraw = true
+		}
+	}
+
+	private handleBefore(event: BeforeEvent): void {
+		const { options, request } = event.detail
+
+		if (options.pdModalPreventRedraw) {
+			request.headers.append('Pd-Modal-Prevent-Redraw', String(1))
+		}
+	}
+}

--- a/src/extensions/AjaxOnceExtension.ts
+++ b/src/extensions/AjaxOnceExtension.ts
@@ -1,0 +1,41 @@
+import { InteractionEvent } from 'naja/dist/core/UIHandler'
+import { Extension, Naja, SuccessEvent } from 'naja/dist/Naja'
+import { isDatasetTruthy } from '../utils'
+
+declare module 'naja/dist/Naja' {
+	interface Options {
+		ajaxOnceInitiator?: HTMLElement | SVGElement
+	}
+}
+
+export class AjaxOnceExtension implements Extension {
+	public initialize(naja: Naja): void {
+		naja.uiHandler.addEventListener('interaction', this.checkAjaxOnce.bind(this))
+		naja.addEventListener('success', this.success.bind(this))
+	}
+
+	private checkAjaxOnce(event: InteractionEvent): void {
+		const { element, options } = event.detail
+
+		if (!isDatasetTruthy(element, 'najaOnce')) {
+			return
+		}
+
+		if (isDatasetTruthy(element, 'najaLoaded')) {
+			event.preventDefault()
+			return
+		}
+
+		options.ajaxOnceInitiator = element as HTMLElement | SVGElement
+	}
+
+	private success(event: SuccessEvent): void {
+		const { options } = event.detail
+
+		if (!options.ajaxOnceInitiator) {
+			return
+		}
+
+		options.ajaxOnceInitiator.dataset.najaLoaded = 'true'
+	}
+}

--- a/src/extensions/ConfirmExtension.ts
+++ b/src/extensions/ConfirmExtension.ts
@@ -1,0 +1,16 @@
+import { Extension, Naja } from 'naja/dist/Naja'
+import { InteractionEvent } from 'naja/dist/core/UIHandler'
+
+export class ConfirmExtension implements Extension {
+	public initialize(naja: Naja): void {
+		naja.uiHandler.addEventListener('interaction', (event: InteractionEvent) => {
+			const { element } = event.detail
+
+			const confirm = element.getAttribute('data-confirm')
+
+			if (confirm && !window.confirm(confirm)) {
+				event.preventDefault()
+			}
+		})
+	}
+}

--- a/src/extensions/FollowUpRequestExtension.ts
+++ b/src/extensions/FollowUpRequestExtension.ts
@@ -1,0 +1,19 @@
+import { Extension, Naja, SuccessEvent } from 'naja/dist/Naja'
+
+declare module 'naja/dist/Naja' {
+	interface Payload {
+		followUpUrl?: string
+	}
+}
+
+export class FollowUpRequestExtension implements Extension {
+	public initialize(naja: Naja): void {
+		naja.addEventListener('success', (event: SuccessEvent) => {
+			const { payload } = event.detail
+
+			if (payload.followUpUrl) {
+				naja.makeRequest('get', payload.followUpUrl, null, { history: false })
+			}
+		})
+	}
+}

--- a/src/extensions/ForceRedirectExtension.ts
+++ b/src/extensions/ForceRedirectExtension.ts
@@ -1,0 +1,35 @@
+import { Extension, Naja, PayloadEvent, SuccessEvent } from 'naja/dist/Naja'
+
+declare module 'naja/dist/Naja' {
+	interface Payload {
+		forceRedirect?: string
+	}
+}
+
+export class ForceRedirectExtension implements Extension {
+	private naja: Naja | undefined
+
+	public initialize(naja: Naja): void {
+		this.naja = naja
+
+		naja.addEventListener('payload', this.prepareOptions.bind(this))
+		naja.addEventListener('success', this.handleForceRedirect.bind(this))
+	}
+
+	private prepareOptions(event: PayloadEvent): void {
+		const { payload, options } = event.detail
+
+		if (payload.forceRedirect) {
+			options.forceRedirect = true
+		}
+	}
+
+	private handleForceRedirect(event: SuccessEvent): void {
+		const { payload } = event.detail
+
+		if (payload.forceRedirect) {
+			this.naja?.redirectHandler.makeRedirect(payload.forceRedirect, true)
+			event.stopImmediatePropagation()
+		}
+	}
+}

--- a/src/extensions/ForceReplaceExtension.ts
+++ b/src/extensions/ForceReplaceExtension.ts
@@ -1,0 +1,35 @@
+import { Extension, Naja } from 'naja/dist/Naja'
+import { BeforeUpdateEvent } from 'naja/dist/core/SnippetHandler'
+import { InteractionEvent } from 'naja/dist/core/UIHandler'
+import { isDatasetTruthy } from '../utils'
+
+declare module 'naja/dist/Naja' {
+	interface Options {
+		forceReplace?: boolean
+	}
+}
+
+export class ForceReplaceExtension implements Extension {
+	private naja: Naja | undefined
+
+	public initialize(naja: Naja): void {
+		this.naja = naja
+
+		naja.uiHandler.addEventListener('interaction', this.checkForceReplace.bind(this))
+		naja.snippetHandler.addEventListener('beforeUpdate', this.handleForceReplace.bind(this))
+	}
+
+	private checkForceReplace(event: InteractionEvent) {
+		const { element, options } = event.detail
+
+		options.forceReplace = isDatasetTruthy(element, 'najaSnippetForceReplace')
+	}
+
+	private handleForceReplace(event: BeforeUpdateEvent): void {
+		const { changeOperation, options } = event.detail
+
+		if (this.naja && options.forceReplace) {
+			changeOperation(this.naja.snippetHandler.op.replace)
+		}
+	}
+}

--- a/src/index.esm.ts
+++ b/src/index.esm.ts
@@ -1,6 +1,12 @@
 import ControlManager from './utils/ControlManager'
 
 export { AjaxModalExtension } from './extensions/AjaxModalExtension'
+export { AjaxModalPreventRedrawExtension } from './extensions/AjaxModalPreventRedrawExtension'
+export { AjaxOnceExtension } from './extensions/AjaxOnceExtension'
+export { ConfirmExtension } from './extensions/ConfirmExtension'
+export { FollowUpRequestExtension } from './extensions/FollowUpRequestExtension'
+export { ForceRedirectExtension } from './extensions/ForceRedirectExtension'
+export { ForceReplaceExtension } from './extensions/ForceReplaceExtension'
 export { SpinnerExtension } from './extensions/SpinnerExtension'
 
 export const controlManager = new ControlManager()

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,5 @@
+export const isDatasetTruthy = (element: Element, datasetName: string): boolean => {
+	const datasetValue = (element as HTMLElement).dataset[datasetName]
+
+	return datasetValue !== undefined && datasetValue !== 'false'
+}

--- a/src/utils/Control.ts
+++ b/src/utils/Control.ts
@@ -4,17 +4,19 @@
 //
 // 1. `constructor` is called immediately and is also called only once. This is the ideal place for e.g. adding common
 //    event handlers to the `body`, or modifying necessary DOM properties on elements not affected by ajax.
-
+//
 // 2. The instantiated class is then added to ControlManager either by `addControlOnLoad` or `addControlOnLive`. This
 //    ensures, that on `DOMContentLoaded` the `initialize` function of class is called. This method should implement
-//    initialization of the control dependent on fully loaded DOM. The `context` argument is equal to `document` in this
-//    call.
+//    initialization of the control dependent on fully loaded DOM. The `context` argument is equal to `document` in this call.
 //
-// 3. In case of `addControlOnLive` used, the `initialize` method is also called for each success ajax request. The
-//    `context` argument is equal to modified nette snippet.
+// 3. In the case of using `addControlOnLive`, two methods are called after each successful Ajax request:
 //
-// There is also optional method `destroy`. This method is called for each snippet before its content is being replaced.
-// It is only called on snippets where operation is equal to naja.snippetHandler.
+//    1. Optional: Just before the snippet update, the optional `destroy` method is called. It will only be called
+//       if the [snippet update operation](https://naja.js.org/#/snippets?id=snippet-update-operation) is `replace`.
+//
+//    2. The `initialize` method is called for each snippet. It is called immediately after the snippet has been
+//       updated. The `context` argument is equal to the modified nette snippet.
+
 export default interface Control {
 	initialize(context: Element | Document): void
 


### PR DESCRIPTION
Added new extensions:
- `AjaxModalPreventRedrawExtension` to prevent modal redraw in certain requests.
- `AjaxOnceExtension` to make specific requests only on the first interaction with the element.
- `ConfirmExtension` to display a native browser confirmation dialogue before making a request.
- `FollowUpRequestExtension` to chain multiple requests one after the other.
- `ForceRedirectExtension` to initiate a force redirect from the backend.
- `ForceReplaceExtension` allowing to change the snippet update operation from `append`/`prepend` to `replace` for specific request initiators.