### PR TITLE
Extension snippet form part

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,10 @@ This extension allows you to force redirect the page to a specific URL. When imp
 ### `ForceReplaceExtension`
 If you are using content prepending or appending on snippets, you may need to force replace their content when certain elements have been interacted with. For example, if you have an infinite pager with new items appended, you may need to clear the snippet when some sort of filtering request has been made. This extension changes the snippet operation to `replace` when enabled by using the `data-naja-snippet-force-replace attribute` on the interacted element. See [Snippet update operation](https://naja.js.org/#/snippets?id=snippet-update-operation) in the Naja docs for more information about update operations.
 
+
+### `SnippetFormPartExtension`
+By default, Naja and netteForms and pdForms expect the snippets to be outer wrappers of the form elements. Because of this, if the snippet is inside the form, the validations and nette toggles may not work properly. This extension simply calls the `Nette.initForm()` method for each form that contains a redrawn snippet. The method itself doesn't attach any handlers if the form has the `formnovalidate` attribute (which it sets itself on initialisation), but the toggles are initialised beforehand.
+
 ### `SpinnerExtension`
 
 This extension allows you to add configurable loading indicator to ajax request. Constructor recieves following 4 parameters:

--- a/src/extensions/SnippetFormPartExtension.ts
+++ b/src/extensions/SnippetFormPartExtension.ts
@@ -1,0 +1,26 @@
+import { AfterUpdateEvent } from 'naja/dist/core/SnippetHandler'
+import { Extension, Naja } from 'naja/dist/Naja'
+
+export class SnippetFormPartExtension implements Extension {
+	private netteForms: any
+
+	public initialize(naja: Naja): void {
+		this.netteForms = naja.formsHandler.netteForms || (window as any).Nette
+
+		if (!this.netteForms) {
+			return
+		}
+
+		naja.snippetHandler.addEventListener('afterUpdate', this.checkSnippetFormPart.bind(this))
+	}
+
+	private checkSnippetFormPart(event: AfterUpdateEvent): void {
+		const { snippet } = event.detail
+
+		const closestForm = snippet.closest('form')
+
+		if (closestForm) {
+			this.netteForms.initForm(closestForm)
+		}
+	}
+}

--- a/src/index.esm.ts
+++ b/src/index.esm.ts
@@ -10,4 +10,6 @@ export { ForceReplaceExtension } from './extensions/ForceReplaceExtension'
 export { SnippetFormPartExtension } from './extensions/SnippetFormPartExtension'
 export { SpinnerExtension } from './extensions/SpinnerExtension'
 
+export { isDatasetTruthy } from './utils'
+
 export const controlManager = new ControlManager()

--- a/src/index.esm.ts
+++ b/src/index.esm.ts
@@ -7,6 +7,7 @@ export { ConfirmExtension } from './extensions/ConfirmExtension'
 export { FollowUpRequestExtension } from './extensions/FollowUpRequestExtension'
 export { ForceRedirectExtension } from './extensions/ForceRedirectExtension'
 export { ForceReplaceExtension } from './extensions/ForceReplaceExtension'
+export { SnippetFormPartExtension } from './extensions/SnippetFormPartExtension'
 export { SpinnerExtension } from './extensions/SpinnerExtension'
 
 export const controlManager = new ControlManager()


### PR DESCRIPTION
- feature: New extension `SnippetFormPartExtension`
  - This extension allows snippets to be used within form elements and ensures that forms are properly initialised
- feature: Export helper function isDatasetTruthy
  - The `isDatasetTruthy` method used by extensions is now exported, so that it can be used in custom extensions as well.