### PR TITLE
New extensions

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -6,6 +6,7 @@ module.exports = {
 	rules: {
 		'@typescript-eslint/ban-ts-comment': 'off',
 		'@typescript-eslint/no-explicit-any': 'off',
+		'@typescript-eslint/no-inferrable-types': 'off',
 		'prettier/prettier': 1
 	},
 	ignorePatterns: ['*.js']

--- a/README.md
+++ b/README.md
@@ -4,7 +4,16 @@
 2. [Utilities](#utilities)
 3. [Extensions](#extensions)
    1. [AjaxModalExtension](#ajaxmodalextension)
-   2. [SpinnerExtension](#spinnerextension)
+   2. [AjaxModalPreventRedrawExtension](#ajaxmodalpreventredrawextension)
+   3. [AjaxOnceExtension](#ajaxonceextension)
+   4. [BtnSpinnerExtension](#btnspinnerextension)
+   5. [ConfirmExtension](#confirmextension)
+   6. [FollowUpRequestExtension](#followuprequestextension)
+   7. [ForceRedirectExtension](#forceredirectextension)
+   8. [ForceReplaceExtension](#forcereplaceextension)
+   9. [SingleSubmitExtension](#singlesubmitextension)
+   10. [SnippetFormPartExtension](#snippetformpartextension)
+   11. [SpinnerExtension](#spinnerextension)
 
 ## Quick start
 ```
@@ -107,6 +116,15 @@ This extension allows you to force redirect the page to a specific URL. When imp
 ### `ForceReplaceExtension`
 If you are using content prepending or appending on snippets, you may need to force replace their content when certain elements have been interacted with. For example, if you have an infinite pager with new items appended, you may need to clear the snippet when some sort of filtering request has been made. This extension changes the snippet operation to `replace` when enabled by using the `data-naja-snippet-force-replace attribute` on the interacted element. See [Snippet update operation](https://naja.js.org/#/snippets?id=snippet-update-operation) in the Naja docs for more information about update operations.
 
+### `SingleSubmitExtension`
+Most of the time it is desirable to allow only single form submissions and prevent duplicate submissions, e.g. by double-clicking a button. This extension disables all buttons within a form on submission. It also works for non-ajax forms where there is a timeout after which the buttons are re-enabled. This extension is enabled by default for all forms, but can be disabled by setting a data attribute `data-naja-single-submit="off"`.
+
+There are 2 parameters passed to the constructor:
+
+| Parameter                      | Description                                                                                                                                                             |
+|--------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `buttonDisabledClass?: string` | Class name added to the buttons disabled by this extension. Defaults to null.                                                                                           |
+| `timeout: number = 60000`      | Timeout in milliseconds after which the spinner is removed for non-ajax forms. Ajax forms will use the Naja / Request API timeout (if there is one). |
 
 ### `SnippetFormPartExtension`
 By default, Naja and netteForms and pdForms expect the snippets to be outer wrappers of the form elements. Because of this, if the snippet is inside the form, the validations and nette toggles may not work properly. This extension simply calls the `Nette.initForm()` method for each form that contains a redrawn snippet. The method itself doesn't attach any handlers if the form has the `formnovalidate` attribute (which it sets itself on initialisation), but the toggles are initialised beforehand.

--- a/README.md
+++ b/README.md
@@ -141,7 +141,8 @@ This extension allows you to add configurable loading indicator to ajax request.
 |`ajaxSpinnerPlaceholderSelector = '.ajax-spinner'`| See below                                                                                                                                                               |
 
 The logic for spinner placeholder is as follows:
-1. Extension can be turned off by using `data-naja-spinner="off"`.
+1. The extension can be disabled by using `data-naja-spinner="off"`.
+3. The extension is also disabled if `data-naja-spinner="btn"` is set. In this case the spinner rendering is up to [`BtnSpinnerExtension`](#btnspinnerextension), which will be enabled automatically.
 2. If there is `data-naja-spinner` with different value, this value is used as a selector for element into which the spinner element is appended.
 3. If there is no `data-naja-spinner`, closest `ajaxSpinnerWrapSelector` is being searched for and:
    1. If there is `ajaxSpinnerPlaceholderSelector` inside, this element is used for placing spinner element.

--- a/README.md
+++ b/README.md
@@ -81,6 +81,20 @@ Occasionally we may have an ajax request invoked inside the modal window, but th
 ### `AjaxOnceExtension`
 This extension allows you to specify for a given element that the request will only be made on the first interaction. For example, for collapsible boxes, it is possible to make the request only once, when they are expanded for the first time. It is enabled by setting `data-naja-once` on the interacted element and allows the same element to control the collapsible box and make a request at the same time, without creating multiple unnecessary requests.
 
+### `BtnSpinnerExtension`
+Extension that allows you to add a spinner element to a certain button. In some cases, the overlay spinner for an area might not be neccessary and overlaying only the button might be sufficient. To use this extension, you have to add a data atributte data-naja-btn-spinner to the button element or data-naja-spinner="btn". In the latter case, the [SpinnerExtension](#spinnerextension) is also disabled automatically.
+
+When loaded, the extension also automatically adds button spinners to all non-ajax forms. This can be disabled on a per-button basis by setting `data-no-spinner` or `data-no-btn-spinner` on the button element.
+
+The extension constructor receives 3 parameters:
+
+| Parameter                                                                | Description                                                                                                                                                             |
+|--------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `spinner: ((props?: any) => Element) \| Element`                         | Mandatory parameter. It should either be function return the spinner element, or directly element.                                                                      |
+| `getSpinnerProps: ((initator: Element) => any) \| undefined = undefined` | If you provide `spinner` as a function, you might also provide function to get settings from ajax initiator. Returned value is passed as a `props` to `spinner()` call. |
+| `timeout: number = 60000`                                                | Timeout in milliseconds after which the spinner is removed for non-ajax forms. Ajax forms will use the Naja / Request API timeout (if there is one).                    |
+
+
 ### `ConfirmExtension`
 Simple extension that uses `window.confirm` before making the request, allowing the user to prevent the request from being made. It is enabled by setting the data attribute `data-confirm`. The value of the attribute is used as a parameter for the `window.confirm` call.
 

--- a/src/extensions/BtnSpinnerExtension.ts
+++ b/src/extensions/BtnSpinnerExtension.ts
@@ -1,0 +1,105 @@
+import { InteractionEvent } from 'naja/dist/core/UIHandler'
+import { CompleteEvent, Extension, Naja, StartEvent } from 'naja/dist/Naja'
+import { isDatasetTruthy } from '../utils'
+
+declare module 'naja/dist/Naja' {
+	interface Options {
+		btnSpinnerInitiator?: Element
+		btnSpinner?: Element
+	}
+}
+
+type spinnerType = ((props?: any) => Element) | Element
+type spinnerPropsFn = ((initiator: Element) => any) | undefined
+
+export class BtnSpinnerExtension implements Extension {
+	public readonly timeout: number
+	public readonly spinner: spinnerType
+	public readonly getSpinnerProps?: spinnerPropsFn
+
+	public constructor(spinner: spinnerType, getSpinnerProps: spinnerPropsFn = undefined, timeout = 60000) {
+		this.spinner = spinner
+		this.getSpinnerProps = getSpinnerProps
+		this.timeout = timeout
+
+		// Handle non-ajax forms as well
+		document.addEventListener('submit', (event: SubmitEvent) => {
+			const form = event.target
+			const button = form ? (form as HTMLFormElement)['nette-submittedBy'] : null
+
+			if (
+				!(form instanceof HTMLFormElement) ||
+				!button ||
+				isDatasetTruthy(button, 'noSpinner') ||
+				isDatasetTruthy(button, 'noBtnSpinner')
+			) {
+				return true
+			}
+
+			const spinner = this.showSpinner(button)
+
+			form.dataset.btnSpinnerTimeout = String(
+				setTimeout(() => {
+					this.hideSpinner(spinner)
+					delete form.dataset.btnSpinnerTimeout
+				}, this.timeout)
+			)
+		})
+	}
+
+	public initialize(naja: Naja): void {
+		// AJAX forms and buttons
+		naja.uiHandler.addEventListener('interaction', this.checkExtensionEnabled.bind(this))
+
+		naja.addEventListener('start', this.handleStartEvent.bind(this))
+		naja.addEventListener('complete', this.handleCompleteEvent.bind(this))
+	}
+
+	private checkExtensionEnabled(event: InteractionEvent): void {
+		const { element } = event.detail
+
+		if (isDatasetTruthy(element, 'najaBtnSpinner') || (element as HTMLElement).dataset.najaSpinner === 'btn') {
+			event.detail.options.btnSpinnerInitiator = element
+		}
+	}
+
+	private handleStartEvent(event: StartEvent): void {
+		const { options } = event.detail
+
+		if (!options.btnSpinnerInitiator) {
+			return
+		}
+
+		options.btnSpinner = this.showSpinner(options.btnSpinnerInitiator)
+	}
+
+	private handleCompleteEvent(event: CompleteEvent): void {
+		const { options } = event.detail
+
+		if (options.forceRedirect || !options.btnSpinner) {
+			return
+		}
+
+		this.hideSpinner(options.btnSpinner)
+	}
+
+	private showSpinner(button: Element): Element {
+		let spinner: Element
+
+		if (typeof this.spinner === 'function') {
+			spinner = this.getSpinnerProps ? this.spinner(this.getSpinnerProps(button)) : this.spinner()
+		} else {
+			spinner = this.spinner
+		}
+
+		button.appendChild(spinner)
+		spinner.animate([{ opacity: 0 }, { opacity: 1 }], { duration: 100 })
+
+		return spinner
+	}
+
+	private hideSpinner(spinner: Element): void {
+		const animation = spinner.animate({ opacity: 0 }, { duration: 100 })
+		animation.finished.then(() => spinner?.remove())
+	}
+}

--- a/src/extensions/SingleSubmitExtension.ts
+++ b/src/extensions/SingleSubmitExtension.ts
@@ -1,0 +1,136 @@
+import { InteractionEvent } from 'naja/dist/core/UIHandler'
+import { CompleteEvent, Extension, Naja, StartEvent } from 'naja/dist/Naja'
+import { isDatasetFalsy } from '../utils'
+
+type HTMLSubmitElement = HTMLButtonElement | HTMLInputElement
+
+declare module 'naja/dist/Naja' {
+	interface Options {
+		singleSubmitForm?: HTMLFormElement
+	}
+}
+
+export class SingleSubmitExtension implements Extension {
+	public timeout: number = 60000
+	public buttonDisabledClass: string | undefined
+	private readonly submitSelector = 'input[type=submit], button[type=submit], input[type=image]'
+
+	public constructor(buttonDisabledClass?: string, timeout: number = 60000) {
+		this.buttonDisabledClass = buttonDisabledClass
+		this.timeout = timeout
+
+		// Handle non-ajax form submission as well
+		document.addEventListener('submit', (event: SubmitEvent) => {
+			const form = event.target
+
+			if (!(form instanceof HTMLFormElement) || this.isExtensionDisabled(form)) {
+				return true
+			}
+
+			this.formSubmitBeforeHandler(form)
+			form.dataset.singleSubmitTimeout = String(
+				setTimeout(() => {
+					this.formSubmitAfterHandler(form)
+				}, this.timeout)
+			)
+		})
+	}
+
+	public initialize(naja: Naja): void {
+		naja.uiHandler.addEventListener('interaction', this.checkExtensionEnabled.bind(this))
+
+		naja.addEventListener('start', (event: StartEvent) => {
+			if (event.detail.options.singleSubmitForm) {
+				this.formSubmitBeforeHandler(event.detail.options.singleSubmitForm)
+			}
+		})
+		naja.addEventListener('complete', (event: CompleteEvent) => {
+			if (event.detail.options.singleSubmitForm) {
+				this.formSubmitAfterHandler(event.detail.options.singleSubmitForm)
+			}
+		})
+	}
+
+	private checkExtensionEnabled(event: InteractionEvent): void {
+		const { element, options } = event.detail
+
+		const inputElement = element as HTMLInputElement
+
+		if (!inputElement.form || this.isExtensionDisabled(inputElement.form)) {
+			return
+		}
+
+		options.singleSubmitForm = inputElement.form
+	}
+
+	private isExtensionDisabled(form: HTMLFormElement): boolean {
+		const button = form['nette-submittedBy'] as HTMLSubmitElement | undefined
+
+		return (button && isDatasetFalsy(button, 'najaSingleSubmit')) || isDatasetFalsy(form, 'najaSingleSubmit')
+	}
+
+	private preventFormSubmit(event: SubmitEvent): void {
+		event.preventDefault()
+	}
+
+	private formSubmitBeforeHandler(form: HTMLFormElement): void {
+		// Non-ajax forms
+		clearTimeout(Number(form.dataset.singleSubmitTimeout))
+		delete form.dataset.singleSubmitTimeout
+
+		form.addEventListener('submit', this.preventFormSubmit)
+
+		// All forms;
+		// Make sure the `disabled` attribute is set after submitting the form.
+		setTimeout(() => {
+			form.querySelectorAll<HTMLSubmitElement>(this.submitSelector).forEach((submit) => {
+				this.disableSubmitElement(submit)
+			})
+		}, 0)
+	}
+
+	private formSubmitAfterHandler(form: HTMLFormElement): void {
+		// Non-ajax forms
+		clearTimeout(Number(form.dataset.singleSubmitTimeout))
+		delete form.dataset.singleSubmitTimeout
+
+		form.removeEventListener('submit', this.preventFormSubmit)
+
+		// All forms;
+		// Ensures that the `disabled` attribute is set only after the `formSubmitBeforeHandler` method has finished;
+		// for example, a request could have been aborted before the `disabled` attribute was set
+		setTimeout(() => {
+			form.querySelectorAll<HTMLSubmitElement>(this.submitSelector).forEach((submit) => {
+				this.enableSubmitElement(submit)
+			})
+		}, 0)
+	}
+
+	private disableSubmitElement(button: HTMLSubmitElement): void {
+		// Handle only non-disabled elements
+		if (button.disabled) {
+			return
+		}
+
+		button.dataset.singleSubmitExtensionDisabled = 'true'
+		button.disabled = true
+
+		if (this.buttonDisabledClass) {
+			button.classList.add(this.buttonDisabledClass)
+		}
+	}
+
+	private enableSubmitElement(button: HTMLSubmitElement): void {
+		// Ensures we only process items we have previously disabled
+		if (!button.dataset.singleSubmitExtensionDisabled) {
+			return
+		}
+
+		delete button.dataset.singleSubmitExtensionDisabled
+		button.disabled = false
+
+		if (this.buttonDisabledClass) {
+			button.classList.remove(this.buttonDisabledClass)
+		}
+	}
+}

--- a/src/extensions/SpinnerExtension.ts
+++ b/src/extensions/SpinnerExtension.ts
@@ -5,9 +5,12 @@ import { InteractionEvent } from 'naja/dist/core/UIHandler'
  * @author Radek Šerý
  *
  * Spinner - loading indicator:
- * 1. Extension can be turned off by using `data-naja-spinner="off"`.
- * 2. If there is `data-naja-spinner` with different value, this value is used as a selector for element into which the spinner element is appended.
- * 3. If there is no `data-naja-spinner`, closest `ajaxSpinnerWrapSelector` is being searched for and:
+ * 1. The extension can be disabled by using `data-naja-spinner="off"`.
+ * 2. The extension is also disabled if `data-naja-spinner="btn"` is set. In this case the spinner rendering is up to
+ *    `BtnSpinnerExtension`, which will be enabled automatically.
+ * 3. If there is `data-naja-spinner` with different value, this value is used as a selector for element into which the
+ *    spinner element is appended.
+ * 4. If there is no `data-naja-spinner`, closest `ajaxSpinnerWrapSelector` is being searched for and:
  *    i.  If there is `ajaxSpinnerPlaceholderSelector` inside, this element is used for placing spinner element.
  *    ii. If not, the spinner element is appended into `ajaxSpinnerWrapSelector` itself.
  */
@@ -105,7 +108,7 @@ export class SpinnerExtension implements Extension {
 		const spinner = element.getAttribute('data-naja-spinner') || null
 		let placeholders: Element[] = []
 
-		if (spinner === 'off') {
+		if (spinner === 'off' || spinner === 'false' || spinner === 'btn') {
 			return []
 		}
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,11 @@
 export const isDatasetTruthy = (element: Element, datasetName: string): boolean => {
 	const datasetValue = (element as HTMLElement).dataset[datasetName]
 
-	return datasetValue !== undefined && datasetValue !== 'false'
+	return datasetValue !== undefined && datasetValue !== 'false' && datasetValue !== 'off'
+}
+
+export const isDatasetFalsy = (element: Element, datasetName: string): boolean => {
+	const datasetValue = (element as HTMLElement).dataset[datasetName]
+
+	return datasetValue === 'off' || datasetValue === 'false'
 }


### PR DESCRIPTION
- [feature: New extension BtnSpinnerExtension](https://github.com/peckadesign/pd-naja/commit/0080623005a7e0012e70dac20281e8bbd7a9cc11)
  - The extension allowing you to use a spinner on a button element.
- [chore: ESLint settings](https://github.com/peckadesign/pd-naja/commit/81474ef581309f3e805f3c0fb6e5f447ea47047c)
- [feature: New extension SingleSubmitExtension](https://github.com/peckadesign/pd-naja/commit/697c99f0f8a35b7663b2755109805f0d2524cdf9)
  - The extension that prevents multiple form submissions due to an error, such as double-clicking the button.
  - New helper method `isDatasetFalsy` to evaluate if the extension should be disabled.
- [feature: SpinnerExtension and BtnSpinnerExtension toggled by single data attribute](https://github.com/peckadesign/pd-naja/commit/747d274f004ed927c52d5bb7d975b9f2624e1fb4)
  - SpinnerExtension can now be disabled with the `data-naja-spinner="btn"` attribute, which also enables BtnSpinnerExtension. This allows you to control these two extensions simultaneously using a single data attribute.