### PR TITLE
fix: The `AjaxModalExtension` respects the `AjaxModalPreventRedrawExtension`

### DIFF
--- a/src/extensions/AjaxModalExtension.ts
+++ b/src/extensions/AjaxModalExtension.ts
@@ -115,7 +115,7 @@ export class AjaxModalExtension implements Extension {
 	}
 
 	private isPdModalRequest = (options: Options): options is OptionsWithPdModal => {
-		return Boolean(options.pdModal)
+		return Boolean(options.pdModal) && !options.pdModalPreventRedraw
 	}
 
 	private isPdModalState = (state: HistoryState | Record<string, never>): state is PdModalHistoryState => {


### PR DESCRIPTION
The `AjaxModalExtension` respects the `AjaxModalPreventRedrawExtension`. If the latter is enabled, the `AjaxModalExtension` is disabled by default.