### PR TITLE
feature: Add `ScrollToExtension` for AJAX requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,9 @@ This extension allows you to force redirect the page to a specific URL. When imp
 ### `ForceReplaceExtension`
 If you are using content prepending or appending on snippets, you may need to force replace their content when certain elements have been interacted with. For example, if you have an infinite pager with new items appended, you may need to clear the snippet when some sort of filtering request has been made. This extension changes the snippet operation to `replace` when enabled by using the `data-naja-snippet-force-replace attribute` on the interacted element. See [Snippet update operation](https://naja.js.org/#/snippets?id=snippet-update-operation) in the Naja docs for more information about update operations.
 
+### `ScrollToExtension`
+Extension that gives you the ability to scroll with the page when the ajax request starts (or finishes). This extension takes a `defaultScrollToEvent: 'before' | 'success'` parameter in the constructor. This parameter defines on which event the scrolling will occur by default. The element to scroll to is defined using a `data-naja-scroll-to` attribute containing selector. You can also change the default value of event per request using `data-naja-scroll-to-event`. It uses the `element.scrollIntoView()` method in the background. There is currently no way to pass arguments to the call.
+
 ### `SingleSubmitExtension`
 Most of the time it is desirable to allow only single form submissions and prevent duplicate submissions, e.g. by double-clicking a button. This extension disables all buttons within a form on submission. It also works for non-ajax forms where there is a timeout after which the buttons are re-enabled. This extension is enabled by default for all forms, but can be disabled by setting a data attribute `data-naja-single-submit="off"`.
 

--- a/src/extensions/ScrollToExtension.ts
+++ b/src/extensions/ScrollToExtension.ts
@@ -1,0 +1,48 @@
+import { InteractionEvent } from 'naja/dist/core/UIHandler'
+import { BeforeEvent, Extension, Naja, SuccessEvent } from 'naja/dist/Naja'
+
+type NajaScrollToEvent = 'before' | 'success'
+
+declare module 'naja/dist/Naja' {
+	interface Options {
+		scrollToEvent?: NajaScrollToEvent
+		scrollToSelector?: string
+	}
+}
+
+export class ScrollToExtension implements Extension {
+	public defaultScrollToEvent: NajaScrollToEvent = 'before'
+
+	public constructor(defaultScrollToEvent?: NajaScrollToEvent) {
+		if (defaultScrollToEvent) {
+			this.defaultScrollToEvent = defaultScrollToEvent
+		}
+	}
+
+	public initialize(naja: Naja): void {
+		naja.uiHandler.addEventListener('interaction', this.checkExtensionEnabled.bind(this))
+		naja.addEventListener('before', this.checkScroll.bind(this))
+		naja.addEventListener('success', this.checkScroll.bind(this))
+	}
+
+	private checkExtensionEnabled(event: InteractionEvent): void {
+		const { element, options } = event.detail
+		const selector = element.getAttribute('data-naja-scroll-to')
+
+		if (selector) {
+			const event = element.getAttribute('data-naja-scroll-to-event') as NajaScrollToEvent | undefined
+
+			options.scrollToSelector = selector
+			options.scrollToEvent = event ?? this.defaultScrollToEvent
+		}
+	}
+
+	private checkScroll(event: BeforeEvent | SuccessEvent): void {
+		const { options } = event.detail
+
+		if (options.scrollToSelector && event.type === options.scrollToEvent) {
+			const scrollToElement = document.querySelector(options.scrollToSelector)
+			scrollToElement?.scrollIntoView()
+		}
+	}
+}


### PR DESCRIPTION
The commit introduces a new `ScrollToExtension` that allows automatic scrolling when AJAX requests start or finish. The event on which the scrolling will be triggered (either `before` or `success`), is defined with the `defaultScrollToEvent` property passed into constructor (`before` is the default). The behavior can be further customised using the `data-naja-scroll-to` and `data-naja-scroll-to-event` HTML attributes. See the readme for a full description