### PR TITLE
feature: Add `ToggleClassExtension` for changing the class names on ajax intearaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,3 +150,18 @@ The logic for spinner placeholder is as follows:
 3. If there is no `data-naja-spinner`, closest `ajaxSpinnerWrapSelector` is being searched for and:
    1. If there is `ajaxSpinnerPlaceholderSelector` inside, this element is used for placing spinner element.
    2. If not, the spinner element is appended into `ajaxSpinnerWrapSelector` itself.
+
+### `ToggleClassExtension`
+
+With this extension you can change the classes on the interacted element immediately at the start of the request. You can use it for example to mark the active element before the ajax finishes. If the request fails with an error (including user interruption), the classes will be reset to the previous state. You can specify the classes to toggle using the data attribute `data-naja-toggle-class`. This attribute expects a JSON object where keys are selectors (used as parameter for the `querySelectorAll` called on the interacted element) and values are class names to be changed. The extension uses the [`toggle()`](https://developer.mozilla.org/en-US/docs/Web/API/DOMTokenList/toggle) function, so it can also remove classes from the element. If you need to change the classes on the interacted element itself, you can use selector `:scope > *`. For example:
+```html
+<a … data-naja-toggle-class='{
+       ":scope > *": "active",
+       "img": "shadow rounded-full"
+   }'>
+	<img … class="shadow">
+	…
+</a>
+```
+
+This configuration would add the `active` class to the anchor element and the `rounded-full` class to the image. It would also remove the `shadow` class from the image as it was already present.

--- a/src/extensions/ToggleClassExtension.ts
+++ b/src/extensions/ToggleClassExtension.ts
@@ -1,0 +1,61 @@
+import { InteractionEvent } from 'naja/dist/core/UIHandler'
+import { CompleteEvent, Extension, Naja, StartEvent } from 'naja/dist/Naja'
+
+type ToggleClassRecord = Record<string, string>
+
+type ToggleClassOptions = {
+	element: Element
+	toggleClass: ToggleClassRecord
+}
+
+declare module 'naja/dist/Naja' {
+	interface Options {
+		toggleClassOptions?: ToggleClassOptions
+	}
+}
+
+export class ToggleClassExtension implements Extension {
+	public initialize(naja: Naja) {
+		naja.uiHandler.addEventListener('interaction', this.checkExtensionEnabled.bind(this))
+		naja.addEventListener('start', this.start.bind(this))
+		naja.addEventListener('complete', this.complete.bind(this))
+	}
+
+	private checkExtensionEnabled(event: InteractionEvent): void {
+		const { element, options } = event.detail
+		const toggleClass = JSON.parse(element.getAttribute('data-naja-toggle-class') || String(null))
+
+		if (toggleClass) {
+			options.toggleClassOptions = {
+				element,
+				toggleClass
+			}
+		}
+	}
+
+	private start(event: StartEvent): void {
+		const { options } = event.detail
+
+		if (options.toggleClassOptions) {
+			this.applyToggleClass(options.toggleClassOptions)
+		}
+	}
+
+	private complete(event: CompleteEvent): void {
+		const { error, options } = event.detail
+
+		if (error && options.toggleClassOptions) {
+			this.applyToggleClass(options.toggleClassOptions)
+		}
+	}
+
+	private applyToggleClass(toggleClassOptions: ToggleClassOptions): void {
+		for (const [selector, classNames] of Object.entries(toggleClassOptions.toggleClass)) {
+			const targets = toggleClassOptions.element.querySelectorAll(selector)
+
+			targets.forEach((target) => {
+				classNames.split(' ').forEach((className) => target.classList.toggle(className))
+			})
+		}
+	}
+}


### PR DESCRIPTION
The newly added `ToggleClassExtension` allows class changes on the interacted elements and its children when a request begins. This can be utilized to indicate an active element before the completion of an AJAX. If an error transpires, it can revert classes to their prior state. Instructions on how to use and implement this have been detailed in README.md.