### PR TITLE
feature: Move Naja to `devDependencies`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,6 @@
 			"name": "@peckadesign/pd-naja",
 			"version": "1.6.0",
 			"license": "MIT",
-			"dependencies": {
-				"naja": "^2.5.0"
-			},
 			"devDependencies": {
 				"@rollup/plugin-babel": "^6.0.3",
 				"@rollup/plugin-commonjs": "^24.1.0",
@@ -21,6 +18,7 @@
 				"eslint-config-prettier": "^8.8.0",
 				"eslint-config-typescript": "^3.0.0",
 				"eslint-plugin-prettier": "^4.2.1",
+				"naja": "2.5.0",
 				"prettier": "^2.8.8",
 				"rollup": "^3.21.6",
 				"typescript": "^5.0.4"
@@ -301,6 +299,7 @@
 			"version": "7.21.5",
 			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.21.5.tgz",
 			"integrity": "sha512-8jI69toZqqcsnqGGqwGS4Qb1VwLOEp4hz+CXPywcvjs60u3B4Pom/U/7rm4W8tMOYEB+E9wgD0mW1l3r8qlI9Q==",
+			"dev": true,
 			"dependencies": {
 				"regenerator-runtime": "^0.13.11"
 			},
@@ -2296,6 +2295,7 @@
 			"version": "2.5.0",
 			"resolved": "https://registry.npmjs.org/naja/-/naja-2.5.0.tgz",
 			"integrity": "sha512-SmGR5VVVtF7jF6EPRkPx+cuhzsxDvKKbs+XO8RO2/2En2l2PBe9LglwFBbYIWMLxeGuYl5wGt2MQvkUjjVaagg==",
+			"dev": true,
 			"dependencies": {
 				"@babel/runtime": "^7.18.3"
 			}
@@ -2518,7 +2518,8 @@
 		"node_modules/regenerator-runtime": {
 			"version": "0.13.11",
 			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
-			"integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
+			"integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+			"dev": true
 		},
 		"node_modules/resolve": {
 			"version": "1.22.2",
@@ -3129,6 +3130,7 @@
 			"version": "7.21.5",
 			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.21.5.tgz",
 			"integrity": "sha512-8jI69toZqqcsnqGGqwGS4Qb1VwLOEp4hz+CXPywcvjs60u3B4Pom/U/7rm4W8tMOYEB+E9wgD0mW1l3r8qlI9Q==",
+			"dev": true,
 			"requires": {
 				"regenerator-runtime": "^0.13.11"
 			}
@@ -4564,6 +4566,7 @@
 			"version": "2.5.0",
 			"resolved": "https://registry.npmjs.org/naja/-/naja-2.5.0.tgz",
 			"integrity": "sha512-SmGR5VVVtF7jF6EPRkPx+cuhzsxDvKKbs+XO8RO2/2En2l2PBe9LglwFBbYIWMLxeGuYl5wGt2MQvkUjjVaagg==",
+			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.18.3"
 			}
@@ -4718,7 +4721,8 @@
 		"regenerator-runtime": {
 			"version": "0.13.11",
 			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
-			"integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
+			"integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+			"dev": true
 		},
 		"resolve": {
 			"version": "1.22.2",

--- a/package.json
+++ b/package.json
@@ -28,9 +28,6 @@
 		"url": "https://github.com/peckadesign/pd-naja/issues"
 	},
 	"homepage": "https://github.com/peckadesign/pd-naja#readme",
-	"dependencies": {
-		"naja": "^2.5.0"
-	},
 	"scripts": {
 		"build": "NODE_ENV=production rollup -c --bundleConfigAsCjs",
 		"lint": "NODE_ENV=development eslint src --ext .ts --max-warnings=0"
@@ -46,6 +43,7 @@
 		"eslint-config-prettier": "^8.8.0",
 		"eslint-config-typescript": "^3.0.0",
 		"eslint-plugin-prettier": "^4.2.1",
+		"naja": "2.5.0",
 		"prettier": "^2.8.8",
 		"rollup": "^3.21.6",
 		"typescript": "^5.0.4"

--- a/src/classes/ControlManager.ts
+++ b/src/classes/ControlManager.ts
@@ -1,19 +1,21 @@
-import naja from 'naja'
 import { AfterUpdateEvent, BeforeUpdateEvent } from 'naja/dist/core/SnippetHandler'
-import Control from './Control'
+import { Naja } from 'naja/dist/Naja'
+import { Control } from '../types'
 
 let instance: ControlManager | null = null
 
-export default class ControlManager {
+export class ControlManager {
+	private naja!: Naja
 	private onLoadControl: Control[] = []
 	private onLiveControl: Control[] = []
 
-	public constructor() {
+	public constructor(naja: Naja) {
 		if (instance === null) {
 			// eslint-disable-next-line @typescript-eslint/no-this-alias
 			instance = this
-			naja.snippetHandler.addEventListener('beforeUpdate', this.onBeforeSnippetUpdate.bind(this))
-			naja.snippetHandler.addEventListener('afterUpdate', this.onSnippetUpdate.bind(this))
+			this.naja = naja
+			this.naja.snippetHandler.addEventListener('beforeUpdate', this.onBeforeSnippetUpdate.bind(this))
+			this.naja.snippetHandler.addEventListener('afterUpdate', this.onSnippetUpdate.bind(this))
 		}
 		return instance
 	}
@@ -25,8 +27,8 @@ export default class ControlManager {
 
 	private onBeforeSnippetUpdate(event: BeforeUpdateEvent): void {
 		if (
-			event.detail.operation === naja.snippetHandler.op.append ||
-			event.detail.operation === naja.snippetHandler.op.prepend
+			event.detail.operation === this.naja.snippetHandler.op.append ||
+			event.detail.operation === this.naja.snippetHandler.op.prepend
 		) {
 			return
 		}

--- a/src/index.esm.ts
+++ b/src/index.esm.ts
@@ -1,4 +1,4 @@
-import ControlManager from './utils/ControlManager'
+export { ControlManager } from './classes/ControlManager'
 
 export { AjaxModalExtension } from './extensions/AjaxModalExtension'
 export { AjaxModalPreventRedrawExtension } from './extensions/AjaxModalPreventRedrawExtension'
@@ -15,5 +15,3 @@ export { SpinnerExtension } from './extensions/SpinnerExtension'
 export { ToggleClassExtension } from './extensions/ToggleClassExtension'
 
 export { isDatasetTruthy, isDatasetFalsy } from './utils'
-
-export const controlManager = new ControlManager()

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,8 +16,7 @@
 //
 //    2. The `initialize` method is called for each snippet. It is called immediately after the snippet has been
 //       updated. The `context` argument is equal to the modified nette snippet.
-
-export default interface Control {
+export interface Control {
 	initialize(context: Element | Document): void
 
 	destroy?(context: Element): void


### PR DESCRIPTION
- Naja has been moved from `dependencies` to `devDependencies`. The library doesn't import Naja's code directly anymore, but only its types.
- `ControlManager` is no longer exported as an instance, only as a class. This is a BC break, as you have to change your project code and instantiate it yourself. The constructor now expects the `naja: Naja` as a parameter.
- The `Control` interface is now exported from a different path. The path `@peckadesign/pd-naja/utils` has been changed to `@peckadesign/pd-naja/types`.