### PR TITLE
refactor: Common methods for handling the spinner have been extracted to `utils`

### DIFF
--- a/src/index.esm.ts
+++ b/src/index.esm.ts
@@ -14,4 +14,4 @@ export { SnippetFormPartExtension } from './extensions/SnippetFormPartExtension'
 export { SpinnerExtension } from './extensions/SpinnerExtension'
 export { ToggleClassExtension } from './extensions/ToggleClassExtension'
 
-export { isDatasetTruthy, isDatasetFalsy } from './utils'
+export { isDatasetFalsy, isDatasetTruthy, showSpinner, hideSpinner } from './utils'

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,11 @@
+export type SpinnerType = ((props?: any) => Element) | Element
+export type SpinnerPropsFn = ((initiator: Element) => any) | undefined
+
+export interface WithSpinner {
+	spinner: SpinnerType
+	getSpinnerProps: SpinnerPropsFn
+}
+
 // `Control` is meant to be used for standalone components, that might be dependent on ajax. It should be used together
 // with ControlManager. Class implementing the `Control` interface should export its instance. Then the intended
 // lifecycle of class is as follows:

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,25 @@
+import { WithSpinner } from './types'
+
+export function showSpinner(this: WithSpinner, target: Element, initiator: Element = target): Element {
+	let spinner: Element
+
+	if (typeof this.spinner === 'function') {
+		spinner = this.getSpinnerProps ? this.spinner(this.getSpinnerProps(initiator)) : this.spinner()
+	} else {
+		spinner = this.spinner
+	}
+
+	target.appendChild(spinner)
+	spinner.animate([{ opacity: 0 }, { opacity: 1 }], { duration: 100 })
+
+	return spinner
+}
+
+export function hideSpinner(spinner: Element): void {
+	const animation = spinner.animate({ opacity: 0 }, { duration: 100 })
+	animation.finished.then(() => spinner?.remove())
+}
+
 export const isDatasetTruthy = (element: Element, datasetName: string): boolean => {
 	const datasetValue = (element as HTMLElement).dataset[datasetName]
 


### PR DESCRIPTION
The common methods for handling the spinner element (show and hide methods specifically) from BtnSpinnerExtension and SpinnerExtension have been extracted to `utils`. Both extensions now use the same code and same types. Both new methods are exported to be used in custom extensions.