### PR TITLE
fix: `ToggleClassExtension` allows to modify class on interacted element itself

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,10 +169,10 @@ At a minimum, these HTML elements are expected for the extension to work:
 
 ### `ToggleClassExtension`
 
-With this extension you can change the classes on the interacted element immediately at the start of the request. You can use it for example to mark the active element before the ajax finishes. If the request fails with an error (including user interruption), the classes will be reset to the previous state. You can specify the classes to toggle using the data attribute `data-naja-toggle-class`. This attribute expects a JSON object where keys are selectors (used as parameter for the `querySelectorAll` called on the interacted element) and values are class names to be changed. The extension uses the [`toggle()`](https://developer.mozilla.org/en-US/docs/Web/API/DOMTokenList/toggle) function, so it can also remove classes from the element. If you need to change the classes on the interacted element itself, you can use selector `:scope > *`. For example:
+With this extension you can change the classes on the interacted element immediately at the start of the request. You can use it for example to mark the active element before the ajax finishes. If the request fails with an error (including user interruption), the classes will be reset to the previous state. You can specify the classes to toggle using the data attribute `data-naja-toggle-class`. This attribute expects a JSON object where keys are selectors (used as parameter for the `querySelectorAll` called on the interacted element) and values are class names to be changed. The extension uses the [`toggle()`](https://developer.mozilla.org/en-US/docs/Web/API/DOMTokenList/toggle) function, so it can also remove classes from the element. If you need to change the classes on the interacted element itself, you can use proprietary selector `:self`. For example:
 ```html
 <a … data-naja-toggle-class='{
-       ":scope > *": "active",
+       ":self": "active",
        "img": "shadow rounded-full"
    }'>
 	<img … class="shadow">

--- a/src/extensions/ToggleClassExtension.ts
+++ b/src/extensions/ToggleClassExtension.ts
@@ -51,7 +51,8 @@ export class ToggleClassExtension implements Extension {
 
 	private applyToggleClass(toggleClassOptions: ToggleClassOptions): void {
 		for (const [selector, classNames] of Object.entries(toggleClassOptions.toggleClass)) {
-			const targets = toggleClassOptions.element.querySelectorAll(selector)
+			const targets =
+				selector === ':self' ? [toggleClassOptions.element] : toggleClassOptions.element.querySelectorAll(selector)
 
 			targets.forEach((target) => {
 				classNames.split(' ').forEach((className) => target.classList.toggle(className))


### PR DESCRIPTION
Proprietary string `:self` can be used as a selector. When used, the interacted element itself is used for `classList` modifications.