### PR TITLE
fix: Better detection of initial state

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
 				"eslint-config-prettier": "^8.8.0",
 				"eslint-config-typescript": "^3.0.0",
 				"eslint-plugin-prettier": "^4.2.1",
-				"naja": "^2.5.0",
+				"naja": "^2.6.0",
 				"prettier": "^2.8.8",
 				"rollup": "^3.21.6",
 				"typescript": "^5.0.4"
@@ -293,18 +293,6 @@
 			},
 			"engines": {
 				"node": ">=6.0.0"
-			}
-		},
-		"node_modules/@babel/runtime": {
-			"version": "7.21.5",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.21.5.tgz",
-			"integrity": "sha512-8jI69toZqqcsnqGGqwGS4Qb1VwLOEp4hz+CXPywcvjs60u3B4Pom/U/7rm4W8tMOYEB+E9wgD0mW1l3r8qlI9Q==",
-			"dev": true,
-			"dependencies": {
-				"regenerator-runtime": "^0.13.11"
-			},
-			"engines": {
-				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/template": {
@@ -2292,13 +2280,11 @@
 			"dev": true
 		},
 		"node_modules/naja": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/naja/-/naja-2.5.0.tgz",
-			"integrity": "sha512-SmGR5VVVtF7jF6EPRkPx+cuhzsxDvKKbs+XO8RO2/2En2l2PBe9LglwFBbYIWMLxeGuYl5wGt2MQvkUjjVaagg==",
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/naja/-/naja-2.6.1.tgz",
+			"integrity": "sha512-xLZPRJeOr6R3Zr5epRDSIzNzsb0RJ9T6LWhcNQbbarMLXQX+O26o1SEENsJ1NWFJfbJe1dWtv+iEiSShSHQZfA==",
 			"dev": true,
-			"dependencies": {
-				"@babel/runtime": "^7.18.3"
-			}
+			"license": "MIT"
 		},
 		"node_modules/natural-compare": {
 			"version": "1.4.0",
@@ -2514,12 +2500,6 @@
 					"url": "https://feross.org/support"
 				}
 			]
-		},
-		"node_modules/regenerator-runtime": {
-			"version": "0.13.11",
-			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
-			"integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
-			"dev": true
 		},
 		"node_modules/resolve": {
 			"version": "1.22.2",
@@ -3125,15 +3105,6 @@
 			"integrity": "sha512-vvPKKdMemU85V9WE/l5wZEmImpCtLqbnTvqDS2U1fJ96KrxoW7KrXhNsNCblQlg8Ck4b85yxdTyelsMUgFUXiw==",
 			"dev": true,
 			"peer": true
-		},
-		"@babel/runtime": {
-			"version": "7.21.5",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.21.5.tgz",
-			"integrity": "sha512-8jI69toZqqcsnqGGqwGS4Qb1VwLOEp4hz+CXPywcvjs60u3B4Pom/U/7rm4W8tMOYEB+E9wgD0mW1l3r8qlI9Q==",
-			"dev": true,
-			"requires": {
-				"regenerator-runtime": "^0.13.11"
-			}
 		},
 		"@babel/template": {
 			"version": "7.22.15",
@@ -4563,13 +4534,10 @@
 			"dev": true
 		},
 		"naja": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/naja/-/naja-2.5.0.tgz",
-			"integrity": "sha512-SmGR5VVVtF7jF6EPRkPx+cuhzsxDvKKbs+XO8RO2/2En2l2PBe9LglwFBbYIWMLxeGuYl5wGt2MQvkUjjVaagg==",
-			"dev": true,
-			"requires": {
-				"@babel/runtime": "^7.18.3"
-			}
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/naja/-/naja-2.6.1.tgz",
+			"integrity": "sha512-xLZPRJeOr6R3Zr5epRDSIzNzsb0RJ9T6LWhcNQbbarMLXQX+O26o1SEENsJ1NWFJfbJe1dWtv+iEiSShSHQZfA==",
+			"dev": true
 		},
 		"natural-compare": {
 			"version": "1.4.0",
@@ -4716,12 +4684,6 @@
 			"version": "1.2.3",
 			"resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
 			"integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-			"dev": true
-		},
-		"regenerator-runtime": {
-			"version": "0.13.11",
-			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
-			"integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
 			"dev": true
 		},
 		"resolve": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
 		"eslint-config-prettier": "^8.8.0",
 		"eslint-config-typescript": "^3.0.0",
 		"eslint-plugin-prettier": "^4.2.1",
-		"naja": "^2.5.0",
+		"naja": "^2.6.0",
 		"prettier": "^2.8.8",
 		"rollup": "^3.21.6",
 		"typescript": "^5.0.4"


### PR DESCRIPTION
The pdModal is not stored in the state if it is the initial state created in Naja's `replaceInitialState`. After the Naja update to 2.6.0 it is easier to detect the initial state and prevent the `pdModal` from being saved in it. This is especially helpful when a non-ajax modal is opened and then navigated. Previously, this was incorrectly detected as a PdModal state because PdModal was already open. Now, in this case, the state correctly contains no `pdModal`, as the non-ajax modal should never appear in the history (and if it does, it shouldn't be handled by the `AjaxModalExtension` anyway).