### PR TITLE
fix: Better detection of non-ajax forms in `BtnSpinnerExtension`

### DIFF
--- a/src/extensions/BtnSpinnerExtension.ts
+++ b/src/extensions/BtnSpinnerExtension.ts
@@ -15,6 +15,8 @@ export class BtnSpinnerExtension implements Extension, WithSpinner {
 	public readonly spinner: SpinnerType
 	public readonly getSpinnerProps: SpinnerPropsFn
 
+	private ajaxFormSelector: string | undefined
+
 	public constructor(spinner: SpinnerType, getSpinnerProps: SpinnerPropsFn = undefined, timeout = 60000) {
 		this.spinner = spinner
 		this.getSpinnerProps = getSpinnerProps
@@ -25,9 +27,12 @@ export class BtnSpinnerExtension implements Extension, WithSpinner {
 			const form = event.target
 			const button = form ? (form as HTMLFormElement)['nette-submittedBy'] : null
 
+			// Skip if the form or button is missing, or if the form is handled by Naja, or if the button explicitly
+			// disables the extension.
 			if (
 				!(form instanceof HTMLFormElement) ||
 				!button ||
+				(this.ajaxFormSelector && (form.matches(this.ajaxFormSelector) || button.matches(this.ajaxFormSelector))) ||
 				isDatasetTruthy(button, 'noSpinner') ||
 				isDatasetTruthy(button, 'noBtnSpinner')
 			) {
@@ -46,6 +51,8 @@ export class BtnSpinnerExtension implements Extension, WithSpinner {
 	}
 
 	public initialize(naja: Naja): void {
+		this.ajaxFormSelector = naja.uiHandler.selector
+
 		// AJAX forms and buttons
 		naja.uiHandler.addEventListener('interaction', this.checkExtensionEnabled.bind(this))
 


### PR DESCRIPTION
In some very rare cases, there could be a duplication of spinners created by this extension in Safari. There the `submit` event on ajax forms is not prevented (in other browsers there's no `submit` event) and if `options.btnSpinnerInitiator` is somehow changed to another element then interacted (for example to some confirmation dialog button), the interacted element received the spinner from the `submit` handler dedicated to non-ajax forms only. Now this listener explicitly checks if the form is not being handled by Naja before it creates its spinner.