### PR TITLE
fix: Retrieve document title when modal is closed

### DIFF
--- a/src/extensions/AjaxModalExtension.ts
+++ b/src/extensions/AjaxModalExtension.ts
@@ -203,6 +203,12 @@ export class AjaxModalExtension implements Extension {
 	private buildState(event: BuildStateEvent): void {
 		const { operation, options, state } = event.detail
 
+		// Always add a `title` into state, so we can retrieve it when needed after closing the modal. See
+		// `popstateHandler` below.
+		if (!state.title) {
+			state.title = document.title
+		}
+
 		// If this is called from Naja's `replaceInitialState`, we don't change the state.
 		//
 		// This is a possible weakness, because this condition could be true even with actual user interaction, if
@@ -365,7 +371,6 @@ export class AjaxModalExtension implements Extension {
 
 				return
 			} else {
-				// Todo check if this is really necessary. When used with nette.ajax / history.nette.ajax, this was necessary in some cases, where the title hasn't been restored correctly.
 				if (state.title) {
 					document.title = state.title
 				}


### PR DESCRIPTION
#26

Inside `popstateHandler` we call `event.stopImmediatePropagation` when the modal is closed. This is to prevent Naja from handling the snippets - as the modal is closed, we don't need to update its snippets and run the code of other extensions. The disadvantage is that if the title is used as a snippet, it will be updated by Naja when the modal is opened and navigated, but it won't be sorted when the modal is closed. We have to change the title with this extension ourselves.