### PR TITLE
feature: More options for Suggest

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ The logic for spinner target is as follows:
    2. If not, the spinner element is appended into `ajaxSpinnerWrapSelector` itself.
 
 
-### `SuggestExtensions`
+### `SuggestExtension`
 This extension allows you to implement a suggestion box. It uses a form element with a dedicated suggestion button to submit the form using ajax. The result of the request is expected to be the redrawing of the snippet with results. See below for a detailed description of the elements. The extension constructor takes optional an `spinnerExtension: SpinnerExtension`, `spinner` and `getSpinnerProps` parameters, the types of the latter two parameters are described in the [`SpinnerExtension`](#spinnerextension) and [`BtnSpinnerExtension`](#btnspinnerextension).
 
 If the `spinnerExtension` is passed and the latter two are omitted, they are set by the passed extension instance. In addition, the target element for the spinner is determined as in the `SpinnerExtension` algorithm (4). The fallback target is always the form element.

--- a/src/classes/Suggest.ts
+++ b/src/classes/Suggest.ts
@@ -4,6 +4,7 @@ import { hideSpinner, showSpinner } from '../utils'
 
 export type SuggestOptions = {
 	minLength: number
+	minLengthForShow: number
 	timeout: number
 	emptyOnNewQuery: boolean
 	showSpinner: boolean
@@ -36,6 +37,7 @@ export class Suggest {
 
 	private readonly options: SuggestOptions = {
 		minLength: 2,
+		minLengthForShow: 2,
 		timeout: 200,
 		emptyOnNewQuery: true,
 		showSpinner: true
@@ -88,7 +90,7 @@ export class Suggest {
 	}
 
 	private showSuggest(): void {
-		if (this.isEmpty() || this.input.value.length < this.options.minLength) {
+		if (this.isEmpty() || this.input.value.length < this.options.minLengthForShow) {
 			return
 		}
 
@@ -201,7 +203,7 @@ export class Suggest {
 
 		const query = this.input.value
 
-		if (query.length < this.options.minLength) {
+		if (query.length < this.options.minLengthForShow) {
 			this.hideSuggest()
 			return
 		}
@@ -216,8 +218,8 @@ export class Suggest {
 			this.showSuggest()
 		}
 
-		// If the query is the same, there's nothing more to do.
-		if (query === this.lastSearched) {
+		// If the query is the same or not long enough, there's nothing more to do.
+		if (query === this.lastSearched || query.length < this.options.minLength) {
 			return
 		}
 
@@ -229,5 +231,10 @@ export class Suggest {
 
 	private handleSuggestMousedown(event: MouseEvent): void {
 		event.preventDefault()
+
+		const target = event.target as HTMLElement
+		if (target.dataset.suggestClose || target.closest('[data-suggest-close]')) {
+			this.input.blur()
+		}
 	}
 }


### PR DESCRIPTION
Suggest can now be shown even with no characters written (e.g. when some default "results" are always present) using `minLengthForShow` setting. It is also possible to close the suggest box by clicking inside the suggest on element `[data-suggest-close]`.