### PR TITLE
fix: `Pd-Modal-Opened header` is always sent

### DIFF
--- a/src/extensions/AjaxModalExtension.ts
+++ b/src/extensions/AjaxModalExtension.ts
@@ -244,13 +244,16 @@ export class AjaxModalExtension implements Extension {
 
 	private before(event: BeforeEvent) {
 		const { options, request } = event.detail
-		if (!this.isPdModalRequest(options)) {
+		const isPdModalRequest = this.isPdModalRequest(options)
+
+		// Set the header according to the modal being already opened or to be opened.
+		request.headers.append('Pd-Modal-Opened', String(Number(this.modal.isShown() || isPdModalRequest)))
+
+		if (!isPdModalRequest) {
 			return
 		}
 
 		this.modal.show(options.modalOpener, options.modalOptions, event)
-
-		request.headers.append('Pd-Modal-Opened', String(Number(this.modal.isShown())))
 	}
 
 	private success(event: SuccessEvent) {


### PR DESCRIPTION
`Pd-Modal-Opened` header always sent. Previously, when the `AjaxModalPreventRedrawExtension` was enabled, the header was not sent even though the modal was indeed open. This is considered a bug, so now the header is always sent and reflects the true state of the modal, whether it is open or not.