### PR TITLE
fix: Use `click()` on `Enter` key for suggestion handling

### DIFF
--- a/src/classes/Suggest.ts
+++ b/src/classes/Suggest.ts
@@ -191,7 +191,7 @@ export class Suggest {
 					event.preventDefault()
 					event.stopPropagation()
 
-					location.href = activeAnchor.href
+					activeAnchor.click()
 				}
 				break
 		}


### PR DESCRIPTION
When using the `Enter` key to activate the selected suggestion result, we now use the `click()` method instead of replacing the location. This allows the application to use AJAX to process the suggestion result. Previously, the Enter key would cause navigation to the page instead of an AJAX request.