### PR TITLE
feature: Optionally call `event.preventDefault()` on Enter key

### DIFF
--- a/src/classes/Suggest.ts
+++ b/src/classes/Suggest.ts
@@ -7,6 +7,7 @@ export type SuggestOptions = {
 	minLengthForShow: number
 	timeout: number
 	emptyOnNewQuery: boolean
+	preventDefaultOnEnter: boolean
 	showSpinner: boolean
 }
 
@@ -40,6 +41,7 @@ export class Suggest {
 		minLengthForShow: 2,
 		timeout: 200,
 		emptyOnNewQuery: true,
+		preventDefaultOnEnter: false,
 		showSpinner: true
 	}
 
@@ -204,7 +206,10 @@ export class Suggest {
 					event.stopPropagation()
 
 					activeAnchor.click()
+				} else if (this.options.preventDefaultOnEnter) {
+					event.preventDefault()
 				}
+
 				break
 		}
 	}


### PR DESCRIPTION
When pressing the Enter key inside a suggest input, developers can now optionally call `event.preventDefault()` unconditionally. Previously, `preventDefault` was only called if a suggest link was selected.