### PR TITLE
feature: `ToggleClassExtension` can handle siblings

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,3 +183,14 @@ With this extension you can change the classes on the interacted element immedia
 ```
 
 This configuration would add the `active` class to the anchor element and the `rounded-full` class to the image. It would also remove the `shadow` class from the image as it was already present.
+
+You can also target elements outside the `:scope` of an element using the proprietary `:parent` selector.
+
+For example, the code below toggles the `active` class on the clicked element while also removing it from the previously active element inside the same parent element. If you click the same element repeatedly, the class remains because it is removed and immediately added back.
+```html
+<a … data-naja-toggle-class='{
+       ":parent .active, :self": "active",
+   }'>
+	…
+</a>
+```

--- a/src/extensions/ToggleClassExtension.ts
+++ b/src/extensions/ToggleClassExtension.ts
@@ -4,7 +4,7 @@ import { CompleteEvent, Extension, Naja, StartEvent } from 'naja/dist/Naja'
 type ToggleClassRecord = Record<string, string>
 
 type ToggleClassOptions = {
-	element: Element
+	element: HTMLElement
 	toggleClass: ToggleClassRecord
 }
 
@@ -15,6 +15,9 @@ declare module 'naja/dist/Naja' {
 }
 
 export class ToggleClassExtension implements Extension {
+	private static selfSelector = ':self'
+	private static parentSelector = ':parent'
+
 	public initialize(naja: Naja) {
 		naja.uiHandler.addEventListener('interaction', this.checkExtensionEnabled.bind(this))
 		naja.addEventListener('start', this.start.bind(this))
@@ -27,7 +30,7 @@ export class ToggleClassExtension implements Extension {
 
 		if (toggleClass) {
 			options.toggleClassOptions = {
-				element,
+				element: element as HTMLElement,
 				toggleClass
 			}
 		}
@@ -51,12 +54,36 @@ export class ToggleClassExtension implements Extension {
 
 	private applyToggleClass(toggleClassOptions: ToggleClassOptions): void {
 		for (const [selector, classNames] of Object.entries(toggleClassOptions.toggleClass)) {
-			const targets =
-				selector === ':self' ? [toggleClassOptions.element] : toggleClassOptions.element.querySelectorAll(selector)
+			const targets = this.getTargetElements(toggleClassOptions.element, selector)
 
 			targets.forEach((target) => {
 				classNames.split(' ').forEach((className) => target.classList.toggle(className))
 			})
 		}
+	}
+
+	private getTargetElements(element: HTMLElement, selector: string): HTMLElement[] {
+		const elements: HTMLElement[] = []
+
+		selector.split(',').forEach((singleSelector) => {
+			elements.push(...this.getTargetElementsSingleSelector(element, singleSelector.trim()))
+		})
+
+		return elements
+	}
+
+	private getTargetElementsSingleSelector(element: HTMLElement, selector: string): HTMLElement[] {
+		let baseElement: Element = element
+
+		if (selector === ToggleClassExtension.selfSelector) {
+			return [element]
+		}
+
+		while (selector.startsWith(ToggleClassExtension.parentSelector) && baseElement.parentElement) {
+			baseElement = baseElement.parentElement
+			selector = selector.slice(ToggleClassExtension.parentSelector.length + 1)
+		}
+
+		return Array.from(baseElement.querySelectorAll(selector))
 	}
 }


### PR DESCRIPTION
`ToggleClassExtension` now supports the proprietary `:parent` selector, allowing you to target and manipulate class of the siblings of the clicked element.