### PR TITLE
fix: Prevent unintended modal redraws for non-pdModal follow-up requests

### DIFF
--- a/src/extensions/AjaxModalExtension.ts
+++ b/src/extensions/AjaxModalExtension.ts
@@ -242,7 +242,7 @@ export class AjaxModalExtension implements Extension {
 		this.historyEnabled = true
 	}
 
-	private before(event: BeforeEvent) {
+	private before(event: BeforeEvent): void {
 		const { options, request } = event.detail
 		const isPdModalRequest = this.isPdModalRequest(options)
 
@@ -250,13 +250,16 @@ export class AjaxModalExtension implements Extension {
 		request.headers.append('Pd-Modal-Opened', String(Number(this.modal.isShown() || isPdModalRequest)))
 
 		if (!isPdModalRequest) {
+			// If the request is not pdModal request, we will prevent modal redraw.
+			request.headers.append('Pd-Modal-Prevent-Redraw', String(1))
+
 			return
 		}
 
 		this.modal.show(options.modalOpener, options.modalOptions, event)
 	}
 
-	private success(event: SuccessEvent) {
+	private success(event: SuccessEvent): void {
 		const { options, payload } = event.detail
 
 		this.popstateFlag = false
@@ -292,7 +295,7 @@ export class AjaxModalExtension implements Extension {
 		}
 	}
 
-	private showHandler() {
+	private showHandler(): void {
 		this.modal.setOptions(this.modalOptions)
 
 		// If the modal history mode is `forwards`, we store the state under the modal, so we can push it as a new state


### PR DESCRIPTION
Starting from version 2.6.0, the `Pd-Modal-Opened` header is always sent with the correct value, regardless of whether the request is a PdModal request. This is intentional, allowing backend components to correctly render depending on whether they’re inside a modal.

However, this behavior introduced a bug when using for example `FollowUpUrlExtension`, which lacks information about the modal context. Since the modal is open, it might be unintentionally redrawn—despite that not being the intended behavior.

To address this, the `AjaxModalExtension` has been updated to also send the `Pd-Modal-Prevent-Redraw` header when the request is not recognized as a PdModal request (as determined by `AjaxModalExtension.isPdModalRequest()`). In most cases, follow-up URLs are not meant to redraw the modal, so this effectively resolves the issue. If a modal redraw is intended, it can be achieved using a `redirect` instead.