### PR TITLE
AjaxModalExtension improvements

### DIFF
--- a/src/extensions/AjaxModalExtension.ts
+++ b/src/extensions/AjaxModalExtension.ts
@@ -385,7 +385,9 @@ export class AjaxModalExtension implements Extension {
 			// We don't want the naja popstate callback to be executed (or any other popstate handler).
 			event.stopImmediatePropagation()
 
-			if (isCurrentStatePdModal) {
+			// If the `state.cursor` is 0, the page has been refreshed, and we don't want to go back in history any
+			// more.
+			if (isCurrentStatePdModal && state.cursor !== 0) {
 				window.history.back()
 
 				return


### PR DESCRIPTION
- ✨**extracted `hideHandler` in `AjaxModalExtension` to handle hide events**
  Extracted the previous functionality into a separate function. Also the hide handler now respects the attribute `data-naja-abort` from the opener, allowing modal requests to finish even when the modal closes. The abort controller now also uses the `uniqueExtKey` property.
- 🐞 **better refresh handling in `AjaxModalExtension`**
  Added a condition to skip `window.history.back()` if `state.cursor` equals 0. This detects if the modal has been refreshed and then opened from another link again. In that case, when closing the modal, we only want to go back in history one step, even though the other state is also pdModal state. But because it has been refreshed (therefore shown outside the modal), it would be unexpected to go back multiple steps.
- 🛠️ **improve comments in `AjaxModalExtension` for clarity and grammar**
Simplified and clarified inline comments in `AjaxModalExtension`, improving grammar, readability, and consistency. No functional changes were made.