### PR TITLE
fix: replace `append` with `set` for headers in AjaxModal extensions

### DIFF
--- a/src/extensions/AjaxModalExtension.ts
+++ b/src/extensions/AjaxModalExtension.ts
@@ -249,7 +249,7 @@ export class AjaxModalExtension implements Extension {
 
 		if (!isPdModalRequest) {
 			// If the request is not pdModal request, we will prevent modal redraw.
-			request.headers.append('Pd-Modal-Prevent-Redraw', String(1))
+			request.headers.set('Pd-Modal-Prevent-Redraw', String(1))
 
 			return
 		}

--- a/src/extensions/AjaxModalPreventRedrawExtension.ts
+++ b/src/extensions/AjaxModalPreventRedrawExtension.ts
@@ -25,7 +25,7 @@ export class AjaxModalPreventRedrawExtension implements Extension {
 		const { options, request } = event.detail
 
 		if (options.pdModalPreventRedraw) {
-			request.headers.append('Pd-Modal-Prevent-Redraw', String(1))
+			request.headers.set('Pd-Modal-Prevent-Redraw', String(1))
 		}
 	}
 }


### PR DESCRIPTION
Updated `AjaxModalExtension` and `AjaxModalPreventRedrawExtension` to use `set` instead of `append` when modifying headers to ensure proper header value replacement.