### PR TITLE
fix: Normalize snippets only for PdModal requests in `AjaxModalExtension`

### DIFF
--- a/src/extensions/AjaxModalExtension.ts
+++ b/src/extensions/AjaxModalExtension.ts
@@ -271,9 +271,9 @@ export class AjaxModalExtension implements Extension {
 	 * structure for Naja and modal updates.
 	 */
 	private normalizePayloadSnippets(event: PayloadEvent): void {
-		const { payload } = event.detail
+		const { payload, options } = event.detail
 
-		if (!payload.snippets) {
+		if (!payload.snippets || !this.isPdModalRequest(options)) {
 			return
 		}
 		const payloadSnippetsIds = Object.keys(payload.snippets)


### PR DESCRIPTION
Snippet normalization should only be performed for requests handled by this extension. Otherwise, snippets could be unintentionally cleared when the page is displayed outside the modal, or if the `PreventModalRedrawExtension` is used inside the modal.