### PR TITLE
ci: migrate npm publish to OIDC trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout 🛎
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node 📦
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: lts/*
           cache: npm
@@ -31,12 +31,14 @@ jobs:
           path: dist/
 
   release:
-    name: Release
+    name: GitHub Release
     runs-on: ubuntu-latest
     needs: [build]
+    permissions:
+      contents: write
     steps:
       - name: Checkout 🛎
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Download artifacts 🧩
         uses: actions/download-artifact@v4
@@ -56,9 +58,12 @@ jobs:
     name: Publish (public)
     runs-on: ubuntu-latest
     needs: [build]
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - name: Checkout 🛎
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Download artifacts 🧩
         uses: actions/download-artifact@v4
@@ -67,15 +72,13 @@ jobs:
           path: dist/
 
       - name: Setup Node 📦
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: lts/*
           registry-url: 'https://registry.npmjs.org'
 
       - name: Publish release 🕊️
-        run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
+        run: npm publish --provenance --access public
 
   publishPrivate:
     name: Publish (private)
@@ -83,7 +86,7 @@ jobs:
     needs: [build]
     steps:
       - name: Checkout 🛎
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Download artifacts 🧩
         uses: actions/download-artifact@v4
@@ -92,7 +95,7 @@ jobs:
           path: dist/
 
       - name: Setup Node 📦
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: lts/*
           registry-url: 'https://npm.pkg.github.com'


### PR DESCRIPTION
## Summary

Migrace publish workflow z `NPM_AUTH_TOKEN` na npm trusted publishing přes OIDC.

## Changes

- 🛠️ `publishPublic`: přidán `permissions: id-token: write` + `contents: read`, odstraněn `NODE_AUTH_TOKEN` (NPM_AUTH_TOKEN), přidán `--provenance` flag
- 🛠️ `release`: přidán `permissions: contents: write`, přejmenován na "GitHub Release"
- 🛠️ Bump `actions/checkout` a `actions/setup-node` na `v5`
- 🛠️ `publishPrivate`: jen bump actions (dál používá `GITHUB_TOKEN`)

## Why

Stávající `NPM_AUTH_TOKEN` může expirovat (přesně to se stalo u `pd-modal`). OIDC trusted publishers nevyžadují žádný secret a poskytují provenance attestaci. Trusted publisher je už nastavený na npmjs.com.

## Reference

Stejná migrace proběhla u `peckadesign/pd-modal`.

## Test plan

- [ ] CI checks projdou na PR
- [ ] Po merge: vytvořit testovací tag, ověřit že `publishPublic` projde s `--provenance` a bez tokenu
- [ ] Ověřit, že balíček na npmjs má provenance badge