### PR TITLE
fix: Set `historyEnabled` only when modal state is pushed in `AjaxModalExtension`

### DIFF
--- a/src/extensions/AjaxModalExtension.ts
+++ b/src/extensions/AjaxModalExtension.ts
@@ -242,9 +242,10 @@ export class AjaxModalExtension implements Extension {
 			}
 		}
 
-		// If the state is build, the history is enabled. This information is needed inside modal callback where the
-		// options are not available, so we store this internally in extension.
-		this.historyEnabled = true
+		// Only mark history as enabled when we actually push/replace a modal state. Otherwise unrelated requests
+		// with `data-naja-history="replace"` would leave `historyEnabled = true` and cause `hiddenHandler` to
+		// call `history.back()` when a non-ajax modal is closed afterwards — navigating the user out of the page.
+		this.historyEnabled = isShown
 	}
 
 	private before(event: BeforeEvent): void {


### PR DESCRIPTION
## Summary

- 🐛 `historyEnabled` was set unconditionally to `true` in `buildState`, leaking across unrelated naja requests
- Now mirrors `isShown` — the flag is only enabled when a modal state was actually pushed/replaced

## Why

Unrelated naja requests using `data-naja-history="replace"` would leave `historyEnabled = true`, and `hiddenHandler` would then call `history.back()` when a non-ajax modal was closed — navigating the user out of the page.

## Test plan

- [ ] CI checks
- [ ] Manuální ověření: stránka s `data-naja-history="replace"` requestem + non-ajax modal — zavření modalu nesmí způsobit navigaci pryč
- [ ] Standardní AJAX modal flow (otevření/zavření) stále funguje včetně `history.back()`