### PR TITLE
ci: Bind GitHub release draft to tag via `gh release create`

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -47,12 +47,9 @@ jobs:
           path: dist/
 
       - name: Create release draft 🕊️
-        uses: softprops/action-gh-release@v2
-        with:
-          draft: true
-          files: |
-            dist/PdNaja.esm.js
-            dist/PdNaja.esm.js.map
+        run: gh release create "${{ github.ref_name }}" --draft --target "${{ github.sha }}" dist/PdNaja.esm.js dist/PdNaja.esm.js.map
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   publishPublic:
     name: Publish (public)


### PR DESCRIPTION
## Summary

- 🛠️ Replace `softprops/action-gh-release@v2` with `gh release create "${{ github.ref_name }}" --draft --target "${{ github.sha }}"` in `publish.yml`

## Why

Previously the draft release got created with an `untagged-<hash>` placeholder slug instead of being bound to the actual pushed tag (e.g. URL `releases/tag/untagged-32cebe2eab...` rather than `releases/tag/3.3.3`). The tag had to be manually re-selected in the GitHub UI before publishing.

Switching to `gh release create` with explicit `tag_name` (via `github.ref_name`) binds the draft to the real tag from the start. This matches the pattern in `prettier-plugin-latte-tailwind` and resolves a recurring problem across our release workflows.

## Test plan

- [ ] Merge & verify CI passes
- [ ] Next release: confirm draft URL appears as `releases/tag/<version>` directly (no `untagged-` slug)
- [ ] Confirm `dist/PdNaja.esm.js` and `dist/PdNaja.esm.js.map` are still attached to the draft