### PR TITLE
fix: Add `tslib` as direct devDependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
 				"eslint-plugin-prettier": "^5.5.4",
 				"prettier": "^3.6.2",
 				"rollup": "^4.52.5",
+				"tslib": "^2.8.1",
 				"typescript": "^5.9.3",
 				"typescript-eslint": "^8.43.0"
 			},
@@ -2781,12 +2782,11 @@
 			}
 		},
 		"node_modules/tslib": {
-			"version": "1.14.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
 			"dev": true,
-			"optional": true,
-			"peer": true
+			"license": "0BSD"
 		},
 		"node_modules/type-check": {
 			"version": "0.4.0",
@@ -4923,12 +4923,10 @@
 			"requires": {}
 		},
 		"tslib": {
-			"version": "1.14.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-			"dev": true,
-			"optional": true,
-			"peer": true
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+			"dev": true
 		},
 		"type-check": {
 			"version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
 		"eslint-plugin-prettier": "^5.5.4",
 		"prettier": "^3.6.2",
 		"rollup": "^4.52.5",
+		"tslib": "^2.8.1",
 		"typescript": "^5.9.3",
 		"typescript-eslint": "^8.43.0"
 	}


### PR DESCRIPTION
## Summary

- 🐞 Add `tslib` (`^2.8.1`) to `devDependencies` in `package.json`
- Lockfile aktualizován pomocí `npm install tslib@^2.6.0 --save-dev`

## Why

`@rollup/plugin-typescript` deklaruje `tslib` jako optional peer dependency. Novější npm verze nehoistují optional peer deps na top-level `node_modules`, takže čistý `npm ci` v CI selhává s:

```
[plugin typescript] @rollup/plugin-typescript: Could not find module 'tslib', which is required by this plugin.
```

Lokálně a na cached CI runs to fungovalo díky předchozí instalaci, čerstvý install spolehlivě padá. Promote na direct devDep tento problém řeší deterministicky.

## Test plan

- [x] Lokální build (`npm run build`) ✅
- [ ] CI passes (čistý `npm ci`)
