### PR TITLE
fix!: Unify AutoSubmitControl data attributes &amp; restore submit-button selection

### DIFF
--- a/src/controls/AutoSubmitControl.ts
+++ b/src/controls/AutoSubmitControl.ts
@@ -64,10 +64,17 @@ export class AutoSubmitControl implements Control {
 		})
 	}
 
-	private handleChange(target: HTMLElement, submit: HTMLElement | null, form: HTMLFormElement): void {
+	private handleChange(target: HTMLElement, fallbackSubmit: HTMLElement | null, form: HTMLFormElement): void {
 		if (isDatasetTruthy(target, 'autoSubmitDisabled')) {
 			return
 		}
+
+		// The element triggering the change may request a specific submit button by its `name` via
+		// `data-auto-submit-submit`; otherwise the `.js-auto-submit__submit` fallback is used.
+		const submitName = target.dataset.autoSubmitSubmit
+		const submit = submitName
+			? ((form.elements.namedItem(submitName) as HTMLElement | null) ?? fallbackSubmit)
+			: fallbackSubmit
 
 		if (submit) {
 			submit.click()

--- a/src/controls/AutoSubmitControl.ts
+++ b/src/controls/AutoSubmitControl.ts
@@ -26,7 +26,7 @@ export class AutoSubmitControl implements Control {
 
 	private initializeForm(form: HTMLFormElement): void {
 		const submit = form.querySelector<HTMLElement>(`${AutoSubmitControl.selector}__submit`)
-		const timeout = form.dataset.autosubmitTimeout ? parseInt(form.dataset.autosubmitTimeout) : 200
+		const timeout = form.dataset.autoSubmitTimeout ? parseInt(form.dataset.autoSubmitTimeout) : 200
 		let timer: ReturnType<typeof setTimeout> | undefined = undefined
 
 		// Delay submission for "text" like inputs where the user writes the input


### PR DESCRIPTION
## Co se mění

`AutoSubmitControl` měl nekonzistentní data atributy a při dřívějším přesunu z projektových implementací do pd-naja přišel o jednu funkci. Tento PR obojí řeší.

### 1. Sjednocení notace `timeout`

Timeout se čte z `data-auto-submit-timeout` (dataset `autoSubmitTimeout`) místo `data-autosubmit-timeout`. Tím všechny atributy controlu sdílí jednu konvenci, která odpovídá i selektoru `.js-auto-submit`:

| Atribut | Před | Po |
|---|---|---|
| timeout | `data-autosubmit-timeout` | `data-auto-submit-timeout` |
| disabled | `data-auto-submit-disabled` | `data-auto-submit-disabled` (beze změny) |
| submit (nově) | — | `data-auto-submit-submit` |

### 2. Výběr submit tlačítka přes `data-auto-submit-submit` (obnovení funkce)

Element, který vyvolá auto-submit, může pomocí `data-auto-submit-submit` určit konkrétní submit tlačítko podle jeho `name` (`form.elements.namedItem(...)`). Když atribut chybí, použije se dosavadní fallback `.js-auto-submit__submit`.

Tato logika existovala v projektových (lokálních) implementacích `AutoSubmitControl` a při přesunu controlu do pd-naja vypadla — projekty se na ni přitom spoléhají (jeden auto-submit formulář s více submit tlačítky → různé serverové handlery podle toho, které pole se změnilo).

## ⚠️ Breaking change

`data-autosubmit-timeout` se už nečte. V markupu ho nahraď za `data-auto-submit-timeout`, jinak control spadne na výchozích 200 ms.

Analýza projektů konzumujících pd-naja přes npm: `data-autosubmit-timeout` nepoužívá žádný z nich → reálný dopad přejmenování je nulový. Projekty s vlastním lokálním forkem controlu (super-zoo, diton, albixon, p7sandbox) změna neovlivňuje. Nová podpora `data-auto-submit-submit` je čistě aditivní.