### PR TITLE
feat: Add CookieConsentExtension

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,14 +8,15 @@
    3. [AjaxOnceExtension](#ajaxonceextension)
    4. [BtnSpinnerExtension](#btnspinnerextension)
    5. [ConfirmExtension](#confirmextension)
-   6. [FollowUpRequestExtension](#followuprequestextension)
-   7. [ForceRedirectExtension](#forceredirectextension)
-   8. [ForceReplaceExtension](#forcereplaceextension)
-   9. [SingleSubmitExtension](#singlesubmitextension)
-   10. [SnippetFormPartExtension](#snippetformpartextension)
-   11. [SpinnerExtension](#spinnerextension)
-   12. [SuggestExtension](#suggestextensions)
-   13. [ToggleClassExtension](#toggleclassextension)
+   6. [CookieConsentExtension](#cookieconsentextension)
+   7. [FollowUpRequestExtension](#followuprequestextension)
+   8. [ForceRedirectExtension](#forceredirectextension)
+   9. [ForceReplaceExtension](#forcereplaceextension)
+   10. [SingleSubmitExtension](#singlesubmitextension)
+   11. [SnippetFormPartExtension](#snippetformpartextension)
+   12. [SpinnerExtension](#spinnerextension)
+   13. [SuggestExtension](#suggestextensions)
+   14. [ToggleClassExtension](#toggleclassextension)
 
 ## Quick start
 ```
@@ -108,6 +109,35 @@ The extension constructor receives 3 parameters:
 
 ### `ConfirmExtension`
 Simple extension that uses `window.confirm` before making the request, allowing the user to prevent the request from being made. It is enabled by setting the data attribute `data-confirm`. The value of the attribute is used as a parameter for the `window.confirm` call.
+
+### `CookieConsentExtension`
+This extension handles a cookie consent bar submitted via Naja. On load it looks for the consent element matching `.js-cookie-consent` and, if found, opens it as an accessible dialog using [`a11y-dialog`](https://a11y-dialog.netlify.app/). The form inside the bar is expected to match `.js-cookie-consent__form`.
+
+When the form is submitted (via Naja), the extension reads the accepted categories and runs the matching scripts that were deferred until consent was given. The behaviour of the buttons is driven by data attributes:
+
+| Attribute                                                          | Element        | Description                                                                                                                                |
+|--------------------------------------------------------------------|----------------|------------------------------------------------------------------------------------------------------------------------------------------|
+| `data-cookie-consent-accept-all`                                   | submit button  | When the form is submitted by this button, all categories are accepted regardless of the checkbox state.                                  |
+| `data-cookie-consent-reject-all`                                   | submit button  | When the form is submitted by this button, no category is accepted (even the checked ones).                                               |
+| `data-cookie-consent-category="<category>"`                        | form input     | Marks an input as belonging to a consent category. The category is accepted when the input is checked (or when "accept all" is used).     |
+| `data-cookie-consent="<category>"`                                 | `<script>` tag | Script that is executed only after consent for the given `<category>` has been granted.                                                   |
+
+Scripts that should wait for consent are rendered as inert `<script type="text/plain" data-cookie-consent="…">` tags. Once their category is accepted, the extension recreates them as runnable `<script>` elements (preserving `src`, `async`, `defer`, `crossOrigin` and `referrerPolicy`).
+
+After a successful submit the bar is closed: the extension dispatches a `cookieConsentBeforeClose` event, sets `data-modal-closing="true"` on the element (so a closing animation can run) and removes the element after the duration read from the `--pd-modal-closing-duration` CSS custom property, finally dispatching `cookieConsentAfterClose`.
+
+This extension depends on [`a11y-dialog`](https://www.npmjs.com/package/a11y-dialog), which is declared as an optional peer dependency. If you use this extension, install it alongside pd-naja:
+
+```
+$ npm install a11y-dialog
+```
+
+```typescript
+import naja from 'naja'
+import { CookieConsentExtension } from '@peckadesign/pd-naja'
+
+naja.registerExtension(new CookieConsentExtension())
+```
 
 ### `FollowUpRequestExtension`
 This extension allows you to chain multiple requests. This is useful, for example, within modals, where after redrawing the modal, you may need to redraw the page below it as well. This page may be from a different presenter, so you need to redraw with a different request. When used, this extension checks for the presence of `followUpUrl` in the payload. This is the URL to which the follow up request will be made.

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
 				"@rollup/plugin-commonjs": "^28.0.9",
 				"@rollup/plugin-node-resolve": "^16.0.3",
 				"@rollup/plugin-typescript": "^12.3.0",
+				"a11y-dialog": "^8.1.4",
 				"eslint": "^9.38.0",
 				"eslint-config-prettier": "^10.1.8",
 				"eslint-plugin-prettier": "^5.5.4",
@@ -23,7 +24,13 @@
 				"typescript-eslint": "^8.43.0"
 			},
 			"peerDependencies": {
+				"a11y-dialog": "^8.1.4",
 				"naja": "^3.3.1"
+			},
+			"peerDependenciesMeta": {
+				"a11y-dialog": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/@ampproject/remapping": {
@@ -1393,6 +1400,16 @@
 				"node": ">=10"
 			}
 		},
+		"node_modules/a11y-dialog": {
+			"version": "8.1.5",
+			"resolved": "https://registry.npmjs.org/a11y-dialog/-/a11y-dialog-8.1.5.tgz",
+			"integrity": "sha512-SlFk3QSqeuvmN/anaIteUkB6ipBHoG1jq5gfQZU2kqvbkDW3Iab7SNufj4io4e8StvuIshD+loJnsQgTEvq6dA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"focusable-selectors": "^0.8.0"
+			}
+		},
 		"node_modules/acorn": {
 			"version": "8.15.0",
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -2043,6 +2060,13 @@
 			"integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
 			"dev": true,
 			"license": "ISC"
+		},
+		"node_modules/focusable-selectors": {
+			"version": "0.8.4",
+			"resolved": "https://registry.npmjs.org/focusable-selectors/-/focusable-selectors-0.8.4.tgz",
+			"integrity": "sha512-0XxbkD0KhOnX10qmnfF9U8DkDD8N/e4M77wMYw2Itoi4vdcoRjSkqXLZFIzkrLIOxzmzCGy88fNG1EbeXMD/zw==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/fsevents": {
 			"version": "2.3.2",
@@ -3984,6 +4008,15 @@
 				}
 			}
 		},
+		"a11y-dialog": {
+			"version": "8.1.5",
+			"resolved": "https://registry.npmjs.org/a11y-dialog/-/a11y-dialog-8.1.5.tgz",
+			"integrity": "sha512-SlFk3QSqeuvmN/anaIteUkB6ipBHoG1jq5gfQZU2kqvbkDW3Iab7SNufj4io4e8StvuIshD+loJnsQgTEvq6dA==",
+			"dev": true,
+			"requires": {
+				"focusable-selectors": "^0.8.0"
+			}
+		},
 		"acorn": {
 			"version": "8.15.0",
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -4417,6 +4450,12 @@
 			"version": "3.3.3",
 			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
 			"integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+			"dev": true
+		},
+		"focusable-selectors": {
+			"version": "0.8.4",
+			"resolved": "https://registry.npmjs.org/focusable-selectors/-/focusable-selectors-0.8.4.tgz",
+			"integrity": "sha512-0XxbkD0KhOnX10qmnfF9U8DkDD8N/e4M77wMYw2Itoi4vdcoRjSkqXLZFIzkrLIOxzmzCGy88fNG1EbeXMD/zw==",
 			"dev": true
 		},
 		"fsevents": {

--- a/package.json
+++ b/package.json
@@ -34,13 +34,20 @@
 	},
 	"sideEffects": false,
 	"peerDependencies": {
+		"a11y-dialog": "^8.1.4",
 		"naja": "^3.3.1"
+	},
+	"peerDependenciesMeta": {
+		"a11y-dialog": {
+			"optional": true
+		}
 	},
 	"devDependencies": {
 		"@rollup/plugin-babel": "^6.1.0",
 		"@rollup/plugin-commonjs": "^28.0.9",
 		"@rollup/plugin-node-resolve": "^16.0.3",
 		"@rollup/plugin-typescript": "^12.3.0",
+		"a11y-dialog": "^8.1.4",
 		"eslint": "^9.38.0",
 		"eslint-config-prettier": "^10.1.8",
 		"eslint-plugin-prettier": "^5.5.4",

--- a/src/extensions/CookieConsentExtension.ts
+++ b/src/extensions/CookieConsentExtension.ts
@@ -1,0 +1,134 @@
+import A11yDialog from 'a11y-dialog'
+import { Extension, InteractionEvent, Naja, SuccessEvent } from 'naja'
+
+declare module 'naja' {
+	interface Options {
+		isCookieConsentRequest?: boolean
+	}
+}
+
+export class CookieConsentExtension implements Extension {
+	private element: HTMLElement | null
+	private form: HTMLFormElement | null
+	private a11yDialog: A11yDialog | undefined
+	private static readonly selector = '.js-cookie-consent'
+
+	public constructor() {
+		this.element = document.querySelector<HTMLElement>(CookieConsentExtension.selector)
+		this.form = this.element?.querySelector<HTMLFormElement>(`${CookieConsentExtension.selector}__form`) || null
+
+		if (!this.element || !this.form) {
+			return
+		}
+
+		this.a11yDialog = new A11yDialog(this.element)
+		this.a11yDialog.show()
+	}
+
+	public initialize(naja: Naja): void {
+		if (this.form === null) {
+			return
+		}
+
+		naja.uiHandler.addEventListener('interaction', this.checkExtensionEnabled.bind(this))
+		naja.addEventListener('success', this.handleSuccess.bind(this))
+	}
+
+	private checkExtensionEnabled(event: InteractionEvent): void {
+		const { element, options } = event.detail
+		const inputElement = element as HTMLInputElement
+
+		options.isCookieConsentRequest = inputElement.form !== null && inputElement.form === this.form
+	}
+
+	private handleSuccess(event: SuccessEvent): void {
+		const { options } = event.detail
+
+		if (!options.isCookieConsentRequest || !this.form) {
+			return
+		}
+
+		const consentCategories = this.getAcceptedCategories(this.form)
+
+		if (consentCategories.length) {
+			const scripts = this.getScripts(consentCategories)
+			this.runScripts(scripts)
+		}
+
+		this.closeCookieConsent()
+	}
+
+	private getAcceptedCategories(form: HTMLFormElement): string[] {
+		const categories: string[] = []
+		const submittedBy = (form as unknown as { 'nette-submittedBy'?: HTMLElement })['nette-submittedBy']
+		const acceptAll: boolean = submittedBy !== undefined && submittedBy.dataset.cookieConsentAcceptAll !== undefined
+		const rejectAll: boolean = submittedBy !== undefined && submittedBy.dataset.cookieConsentRejectAll !== undefined
+
+		if (rejectAll) {
+			return []
+		}
+
+		for (let i = 0; i < form.elements.length; i++) {
+			const input = form.elements[i] as HTMLInputElement
+			const consent = input.dataset.cookieConsentCategory
+
+			if (consent && (acceptAll || input.checked)) {
+				categories.push(consent)
+			}
+		}
+
+		return categories
+	}
+
+	private getScripts(categories: string[]): NodeListOf<HTMLScriptElement> {
+		const selectors: string[] = []
+
+		categories.forEach((category) => {
+			selectors.push(`script[data-cookie-consent="${category}"]`)
+		})
+
+		return document.querySelectorAll<HTMLScriptElement>(selectors.join(','))
+	}
+
+	private runScripts(scripts: NodeListOf<HTMLScriptElement>): void {
+		scripts.forEach((script) => this.runScript(script))
+	}
+
+	private runScript(script: HTMLScriptElement): void {
+		const scriptRunnable = document.createElement('script')
+
+		if (script.src) {
+			scriptRunnable.src = script.src
+		} else {
+			scriptRunnable.innerHTML = script.innerHTML
+		}
+
+		scriptRunnable.async = script.async
+		scriptRunnable.defer = script.defer
+
+		scriptRunnable.crossOrigin = script.crossOrigin
+		scriptRunnable.referrerPolicy = script.referrerPolicy
+
+		script.insertAdjacentElement('afterend', scriptRunnable)
+		script.remove()
+	}
+
+	private closeCookieConsent(): void {
+		if (!this.element) {
+			return
+		}
+
+		document.dispatchEvent(new CustomEvent('cookieConsentBeforeClose', { bubbles: true }))
+
+		const closingDuration = parseInt(
+			getComputedStyle(this.element).getPropertyValue('--pd-modal-closing-duration') || '0'
+		)
+
+		this.element.dataset.modalClosing = 'true'
+
+		setTimeout(() => {
+			this.element?.remove()
+			document.dispatchEvent(new CustomEvent('cookieConsentAfterClose', { bubbles: true }))
+		}, closingDuration)
+	}
+}

--- a/src/index.esm.ts
+++ b/src/index.esm.ts
@@ -6,6 +6,7 @@ export { AjaxModalPreventRedrawExtension } from './extensions/AjaxModalPreventRe
 export { AjaxOnceExtension } from './extensions/AjaxOnceExtension'
 export { BtnSpinnerExtension } from './extensions/BtnSpinnerExtension'
 export { ConfirmExtension } from './extensions/ConfirmExtension'
+export { CookieConsentExtension } from './extensions/CookieConsentExtension'
 export { FollowUpRequestExtension } from './extensions/FollowUpRequestExtension'
 export { ForceRedirectExtension } from './extensions/ForceRedirectExtension'
 export { ForceReplaceExtension } from './extensions/ForceReplaceExtension'


### PR DESCRIPTION
## What's Changed

* ✨ **Add `CookieConsentExtension`** for handling a cookie consent bar submitted via Naja.

On load, the extension finds the consent element matching `.js-cookie-consent` and opens it as an accessible dialog using [`a11y-dialog`](https://a11y-dialog.netlify.app/). After a successful submit it reads the accepted categories (driven by `data-cookie-consent-accept-all` / `data-cookie-consent-reject-all` buttons and `data-cookie-consent-category` inputs), runs the deferred `<script data-cookie-consent="…">` tags for the accepted categories, and closes the bar with a `cookieConsentBeforeClose` / `cookieConsentAfterClose` event pair and a closing animation driven by `--pd-modal-closing-duration`.

### Notes

* `a11y-dialog` is declared as an **optional peer dependency** (`peerDependenciesMeta.a11y-dialog.optional = true`). Projects that don't use this extension are not forced to install it and won't get a missing-peer warning; thanks to tree-shaking (`sideEffects: false`) it is also kept out of the bundle. Projects using the extension install `a11y-dialog` alongside pd-naja (typically already present via pd-modal).
* README updated with the new extension's documentation.
